### PR TITLE
Fix behavior around tile entity deletion

### DIFF
--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/MagicMirrorBlock.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/MagicMirrorBlock.java
@@ -118,21 +118,6 @@ public class MagicMirrorBlock extends HorizontalBlock {
     }
 
     @Override
-    public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos, boolean isMoving) {
-        super.neighborChanged(state, worldIn, pos, blockIn, fromPos, isMoving);
-
-        // Break the mirror if the other part is broken.
-        if (state.get(COMPLETE)) {
-            if (
-                    state.get(PART) == EnumPartType.TOP && worldIn.getBlockState(pos.down()).getBlock() != this ||
-                            state.get(PART) == EnumPartType.BOTTOM && worldIn.getBlockState(pos.up()).getBlock() != this
-            ) {
-                worldIn.setBlockState(pos, state.with(COMPLETE, false));
-            }
-        }
-    }
-
-    @Override
     protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
         builder.add(HORIZONTAL_FACING, COMPLETE, PART);
     }
@@ -221,6 +206,13 @@ public class MagicMirrorBlock extends HorizontalBlock {
             TileEntity tileEntity = worldIn.getTileEntity(pos);
             if (tileEntity instanceof MagicMirrorBaseTileEntity) {
                 ((MagicMirrorBaseTileEntity) tileEntity).removeModifiers(worldIn, pos);
+            }
+
+            // Change the other part to incomplete
+            BlockPos otherPos = state.get(PART) == EnumPartType.TOP ? pos.down() : pos.up();
+            BlockState otherState = worldIn.getBlockState(otherPos);
+            if (otherState.getBlock() == this) {
+                worldIn.setBlockState(otherPos, otherState.with(COMPLETE, false));
             }
         }
         super.onReplaced(state, worldIn, pos, newState, isMoving);

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/tileentities/MagicMirrorBaseTileEntity.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/tileentities/MagicMirrorBaseTileEntity.java
@@ -113,11 +113,4 @@ public abstract class MagicMirrorBaseTileEntity extends TileEntity {
     public EnumPartType getPart() {
         return getBlockState().get(MagicMirrorBlock.PART);
     }
-
-    /**
-     * @return Whether the mirror is completely constructed.
-     */
-    public boolean isComplete() {
-        return getBlockState().get(MagicMirrorBlock.COMPLETE);
-    }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/tileentities/MagicMirrorPartTileEntity.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/tileentities/MagicMirrorPartTileEntity.java
@@ -24,9 +24,6 @@ public class MagicMirrorPartTileEntity extends MagicMirrorBaseTileEntity {
     @Nullable
     @Override
     protected MagicMirrorCoreTileEntity getCore() {
-        if (!isComplete()) {
-            return null;
-        }
         if (core == null) {
             World world = getWorld();
             if (world != null) {

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/TileEntityMagicMirrorRenderer.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/TileEntityMagicMirrorRenderer.java
@@ -38,20 +38,18 @@ class TileEntityMagicMirrorRenderer extends TileEntityRenderer<MagicMirrorBaseTi
     public void render(MagicMirrorBaseTileEntity te, double x, double y, double z, float partialTicks, int destroyStage) {
         super.render(te, x, y, z, partialTicks, destroyStage);
 
-        if (te.isComplete()) {
-            Reflection reflection = te.getReflection();
+        Reflection reflection = te.getReflection();
 
-            if (reflection != null) {
-                Entity reflected = reflection.getReflectedEntity();
-                if (reflected != null) {
-                    EnumPartType part = te.getPart();
-                    Direction facing = te.getFacing();
+        if (reflection != null) {
+            Entity reflected = reflection.getReflectedEntity();
+            if (reflected != null) {
+                EnumPartType part = te.getPart();
+                Direction facing = te.getFacing();
 
-                    Vec3d reflectedPos = reflected.getPositionVector();
-                    double distanceSq = te.getPos().distanceSq(reflectedPos.x, reflectedPos.y, reflectedPos.z, true);
+                Vec3d reflectedPos = reflected.getPositionVector();
+                double distanceSq = te.getPos().distanceSq(reflectedPos.x, reflectedPos.y, reflectedPos.z, true);
 
-                    renderReflection(reflection, x, y, z, partialTicks, part, facing, distanceSq);
-                }
+                renderReflection(reflection, x, y, z, partialTicks, part, facing, distanceSq);
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ subprojects {
     }
 
     dependencies {
-        minecraft "net.minecraftforge:forge:1.14.4-28.2.3"
+        minecraft "net.minecraftforge:forge:1.14.4-28.2.16"
 
         implementation 'com.google.code.findbugs:jsr305:3.0.2'
     }


### PR DESCRIPTION
I fixed the behavior around `hasTileEntity` checks in Forge 1.14.4-28.2.15.
Unfortunately, this now causes the TE to be deleted properly, causing errors.

This PR fixes that and also gets rid of unnecessary `isComplete` checks. If the TE exists, that means the mirror is complete.