### PR TITLE
Make doorway particles the right texture.

### DIFF
--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/MagicDoorwayPartBaseBlock.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/MagicDoorwayPartBaseBlock.java
@@ -7,6 +7,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.client.particle.ParticleManager;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
@@ -74,6 +75,17 @@ public abstract class MagicDoorwayPartBaseBlock extends Block {
             return ((MagicDoorwayPartBaseTileEntity) tileEntity).getBaseBlockState().getSlipperiness(world, pos, entity);
         }
         return super.getSlipperiness(state, world, pos, entity);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public float getPlayerRelativeBlockHardness(BlockState state, PlayerEntity player, IBlockReader worldIn, BlockPos pos) {
+        // Use the base block's hardness.
+        TileEntity tileEntity = worldIn.getTileEntity(pos);
+        if (tileEntity instanceof MagicDoorwayPartBaseTileEntity) {
+            return ((MagicDoorwayPartBaseTileEntity) tileEntity).getBaseBlockState().getPlayerRelativeBlockHardness(player, worldIn, pos);
+        }
+        return super.getPlayerRelativeBlockHardness(state, player, worldIn, pos);
     }
 
     @Override

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/tileentities/MagicDoorwayPartBaseTileEntity.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/tileentities/MagicDoorwayPartBaseTileEntity.java
@@ -3,6 +3,7 @@ package com.tomboshoven.minecraft.magicdoorknob.blocks.tileentities;
 import com.tomboshoven.minecraft.magicdoorknob.items.Items;
 import com.tomboshoven.minecraft.magicdoorknob.items.MagicDoorknobItem;
 import com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured.ModelTextureProperty;
+import com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured.ModelTextureProperty.ModelParticleTextureProperty;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -46,6 +47,11 @@ public abstract class MagicDoorwayPartBaseTileEntity extends TileEntity {
      * The highlight texture of the doorway (based on doorknob).
      */
     private static final ModelTextureProperty TEXTURE_HIGHLIGHT = ModelTextureProperty.get(new ResourceLocation(PROPERTY_NAMESPACE, "texture_highlight"));
+
+    /**
+     * The particle texture of the doorway (based on base block).
+     */
+    private static final ModelParticleTextureProperty TEXTURE_PARTICLE = ModelTextureProperty.getParticleProperty();
 
     // The block we're basing the appearance of this block on.
     private BlockState baseBlockState = Blocks.AIR.getDefaultState();
@@ -134,6 +140,7 @@ public abstract class MagicDoorwayPartBaseTileEntity extends TileEntity {
         CompositeModel.CompositeModelData compositeModelData = new CompositeModel.CompositeModelData();
         compositeModelData.setData(TEXTURE_MAIN, blockMaterial);
         compositeModelData.setData(TEXTURE_HIGHLIGHT, doorknobMaterial);
+        compositeModelData.setData(TEXTURE_PARTICLE, blockMaterial);
         return compositeModelData;
     }
 

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ITextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ITextureMapper.java
@@ -24,4 +24,10 @@ public interface ITextureMapper {
      * @return The appropriate material
      */
     RenderMaterial mapSprite(PropertySprite spriteToMap, @Nullable BlockState blockState, @Nullable IModelData extraData);
+
+    /**
+     * @param extraData   Extra model data if available
+     * @return The location of the appropriate particle texture
+     */
+    RenderMaterial getParticleTexture(@Nullable IModelData extraData);
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelDataTextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelDataTextureMapper.java
@@ -33,4 +33,16 @@ class ModelDataTextureMapper implements ITextureMapper {
         }
         return new RenderMaterial(PlayerContainer.LOCATION_BLOCKS_TEXTURE, MissingTextureSprite.getLocation());
     }
+
+    @Override
+    public RenderMaterial getParticleTexture(@Nullable IModelData extraData) {
+        if (extraData != null) {
+            ModelProperty<RenderMaterial> modelProperty = ModelTextureProperty.getParticleProperty();
+            RenderMaterial spriteLocation = extraData.getData(modelProperty);
+            if (spriteLocation != null) {
+                return spriteLocation;
+            }
+        }
+        return new RenderMaterial(PlayerContainer.LOCATION_BLOCKS_TEXTURE, MissingTextureSprite.getLocation());
+    }
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelTextureProperty.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelTextureProperty.java
@@ -19,6 +19,7 @@ public final class ModelTextureProperty extends ModelProperty<RenderMaterial> {
     // Lazily filled map of model texture properties.
     // Can't just use equality as they are used in an IdentityHashMap.
     private static final Map<ResourceLocation, ModelTextureProperty> PROPERTIES = Maps.newHashMap();
+    private static final ModelParticleTextureProperty PARTICLE_PROPERTY = new ModelParticleTextureProperty();
 
     private final ResourceLocation name;
 
@@ -40,6 +41,10 @@ public final class ModelTextureProperty extends ModelProperty<RenderMaterial> {
         return PROPERTIES.computeIfAbsent(name, ModelTextureProperty::new);
     }
 
+    public static ModelParticleTextureProperty getParticleProperty() {
+        return PARTICLE_PROPERTY;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -52,4 +57,6 @@ public final class ModelTextureProperty extends ModelProperty<RenderMaterial> {
     public int hashCode() {
         return Objects.hash(name);
     }
+
+    public static class ModelParticleTextureProperty extends ModelProperty<RenderMaterial> {}
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedBakedModel.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedBakedModel.java
@@ -23,6 +23,7 @@ import net.minecraftforge.client.model.BakedModelWrapper;
 import net.minecraftforge.client.model.data.EmptyModelData;
 import net.minecraftforge.client.model.data.IModelData;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
@@ -159,6 +160,12 @@ class TexturedBakedModel<T extends IBakedModel> extends BakedModelWrapper<T> {
     @Override
     public ItemOverrideList getOverrides() {
         return new TexturedOverrideList(super.getOverrides());
+    }
+
+    @Override
+    public TextureAtlasSprite getParticleTexture(@Nonnull IModelData data) {
+        RenderMaterial particleTextureLocation = textureMapper.getParticleTexture(data);
+        return bakedTextureGetter.apply(particleTextureLocation);
     }
 
     /**

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_door_bottom.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_door_bottom.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "door": {
       "parent": "magic_doorknob:block/part/magic_door"

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_door_top.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_door_top.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "door": {
       "parent": "magic_doorknob:block/part/magic_door"

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_closed_bottom.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_closed_bottom.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "pillar1": {
       "parent": "magic_doorknob:block/part/magic_doorway_wall"

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_closed_top.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_closed_top.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "top": {
       "parent": "magic_doorknob:block/part/magic_doorway_top"

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_half_open_bottom.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_half_open_bottom.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "wall1": {
       "parent": "magic_doorknob:block/part/magic_doorway_wall"

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_half_open_top.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_half_open_top.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "top": {
       "parent": "magic_doorknob:block/part/magic_doorway_top"

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_open_bottom.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_open_bottom.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "pillar1": {
       "parent": "magic_doorknob:block/part/magic_doorway_pillar"

--- a/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_open_top.json
+++ b/MagicDoorknob/src/main/resources/assets/magic_doorknob/models/block/magic_doorway_open_top.json
@@ -1,8 +1,6 @@
 {
-  "loader": "forge:composite",
-  "textures": {
-    "particle": "minecraft:block/obsidian"
-  },
+  "loader": "magic_doorknob:textured",
+  "base_loader": "forge:composite",
   "parts": {
     "top": {
       "parent": "magic_doorknob:block/part/magic_doorway_top"


### PR DESCRIPTION
This is something I couldn't do in 1.12.2, but it seems it's been possible since 1.14.4.
Also fix a block hardness issue.