### PR TITLE
Netherite doorknob

### DIFF
--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Language.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Language.java
@@ -27,6 +27,7 @@ class Language extends LanguageProvider {
         addDoorknob("diamond");
         addDoorknob("gold", "Golden");
         addDoorknob("iron");
+        addDoorknob("netherite");
         addDoorknob("stone");
         addDoorknob("wood", "Wooden");
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Recipes.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Recipes.java
@@ -30,7 +30,7 @@ class Recipes extends RecipeProvider {
                         .patternLine(" # ")
                         .patternLine("#@#")
                         .patternLine(" # ")
-                        .key('#', doorknob.getRecipeTag())
+                        .key('#', doorknob.getIngredient())
                         .key('@', Tags.Items.ENDER_PEARLS)
                         .setGroup("magic_doorknob")
                         .addCriterion("ender_pearls", InventoryChangeTrigger.Instance.forItems(ENDER_PEARL))

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/Items.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/Items.java
@@ -3,11 +3,12 @@ package com.tomboshoven.minecraft.magicdoorknob.items;
 import com.google.common.collect.Maps;
 import com.tomboshoven.minecraft.magicdoorknob.MagicDoorknobMod;
 import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.block.Blocks;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemTier;
-import net.minecraft.tags.ITag.INamedTag;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.Tags;
@@ -18,6 +19,7 @@ import net.minecraftforge.registries.IForgeRegistry;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Collection of all items in the mod.
@@ -39,14 +41,14 @@ public final class Items {
      * <p>
      * Make sure to add a translation key.
      *
-     * @param registry  The registry to which to add the doorknob item.
+     * @param registry    The registry to which to add the doorknob item.
      * @param typeName    The type name of the item. Keep this stable, since it is used in NBT data.
      * @param tier        The material this doorknob is made of
      * @param mainTexture The main texture of the doorknob
-     * @param recipeTag   The tag to use in recipes
+     * @param ingredient  The ingredient used to build the doorknob
      */
-    private static void addDoorknob(IForgeRegistry<? super Item> registry, String typeName, IItemTier tier, ResourceLocation mainTexture, INamedTag<Item> recipeTag) {
-        MagicDoorknobItem i = new MagicDoorknobItem(new Item.Properties().group(ItemGroup.TOOLS), typeName, tier, mainTexture, recipeTag);
+    private static void addDoorknob(IForgeRegistry<? super Item> registry, String typeName, IItemTier tier, ResourceLocation mainTexture, Supplier<Ingredient> ingredient) {
+        MagicDoorknobItem i = new MagicDoorknobItem(new Item.Properties().group(ItemGroup.TOOLS), typeName, tier, mainTexture, ingredient);
         i.setRegistryName(MagicDoorknobMod.MOD_ID, String.format("magic_doorknob_%s", typeName));
         registry.register(i);
         DOORKNOBS.put(typeName, i);
@@ -59,10 +61,10 @@ public final class Items {
      * @param typeName  The type name of the item. Keep this stable, since it is used in NBT data.
      * @param tier      The material this doorknob is made of
      * @param blockName The name of the block that provides the texture of the doorknob
-     * @param recipeTag The tag to use in recipes
+     * @param ingredient  The ingredient used to build the doorknob
      */
-    private static void addDoorknob(IForgeRegistry<? super Item> registry, String typeName, IItemTier tier, String blockName, INamedTag<Item> recipeTag) {
-        addDoorknob(registry, typeName, tier, new ResourceLocation("minecraft", String.format("block/%s", blockName)), recipeTag);
+    private static void addDoorknob(IForgeRegistry<? super Item> registry, String typeName, IItemTier tier, String blockName, Supplier<Ingredient> ingredient) {
+        addDoorknob(registry, typeName, tier, new ResourceLocation("minecraft", String.format("block/%s", blockName)), ingredient);
     }
 
     public static void register(IEventBus eventBus) {
@@ -73,10 +75,11 @@ public final class Items {
         IForgeRegistry<Item> registry = event.getRegistry();
 
         // Add all Vanilla tool materials
-        addDoorknob(registry, "wood", ItemTier.WOOD, "oak_planks", ItemTags.PLANKS);
-        addDoorknob(registry, "stone", ItemTier.STONE, "stone", Tags.Items.COBBLESTONE);
-        addDoorknob(registry, "iron", ItemTier.IRON, "iron_block", Tags.Items.INGOTS_IRON);
-        addDoorknob(registry, "gold", ItemTier.GOLD, "gold_block", Tags.Items.INGOTS_GOLD);
-        addDoorknob(registry, "diamond", ItemTier.DIAMOND, "diamond_block", Tags.Items.GEMS_DIAMOND);
+        addDoorknob(registry, "wood", ItemTier.WOOD, "oak_planks", () -> Ingredient.fromTag(ItemTags.PLANKS));
+        addDoorknob(registry, "stone", ItemTier.STONE, "stone", () -> Ingredient.fromTag(Tags.Items.COBBLESTONE));
+        addDoorknob(registry, "iron", ItemTier.IRON, "iron_block", () -> Ingredient.fromTag(Tags.Items.INGOTS_IRON));
+        addDoorknob(registry, "gold", ItemTier.GOLD, "gold_block", () -> Ingredient.fromTag(Tags.Items.INGOTS_GOLD));
+        addDoorknob(registry, "diamond", ItemTier.DIAMOND, "diamond_block", () -> Ingredient.fromTag(Tags.Items.GEMS_DIAMOND));
+        addDoorknob(registry, "netherite", ItemTier.NETHERITE, "netherite_block", () -> Ingredient.fromItems(Blocks.field_235397_ng_));
     }
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/Items.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/Items.java
@@ -3,7 +3,6 @@ package com.tomboshoven.minecraft.magicdoorknob.items;
 import com.google.common.collect.Maps;
 import com.tomboshoven.minecraft.magicdoorknob.MagicDoorknobMod;
 import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.block.Blocks;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
@@ -80,6 +79,6 @@ public final class Items {
         addDoorknob(registry, "iron", ItemTier.IRON, "iron_block", () -> Ingredient.fromTag(Tags.Items.INGOTS_IRON));
         addDoorknob(registry, "gold", ItemTier.GOLD, "gold_block", () -> Ingredient.fromTag(Tags.Items.INGOTS_GOLD));
         addDoorknob(registry, "diamond", ItemTier.DIAMOND, "diamond_block", () -> Ingredient.fromTag(Tags.Items.GEMS_DIAMOND));
-        addDoorknob(registry, "netherite", ItemTier.NETHERITE, "netherite_block", () -> Ingredient.fromItems(Blocks.field_235397_ng_));
+        addDoorknob(registry, "netherite", ItemTier.NETHERITE, "netherite_block", () -> Ingredient.fromItems(net.minecraft.item.Items.field_234759_km_));
     }
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/MagicDoorknobItem.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/MagicDoorknobItem.java
@@ -15,7 +15,7 @@ import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemUseContext;
-import net.minecraft.tags.ITag.INamedTag;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
@@ -29,6 +29,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Supplier;
 
 /**
  * A magic doorknob that allows you to open doors that don't exist.
@@ -42,23 +43,23 @@ public class MagicDoorknobItem extends Item {
     private final String typeName;
     // The item material, used for determining doorway generation properties
     private final IItemTier tier;
-    // The item tag to use in recipes
-    private final INamedTag<Item> recipeTag;
+    // The ingredient used to make doorknobs of this type
+    private final Supplier<Ingredient> ingredient;
 
     /**
      * @param properties          The item properties
      * @param typeName            The main texture of the item
      * @param tier                The item material, used for determining doorway generation properties
      * @param mainTextureLocation The main material for rendering the block
-     * @param recipeTag           The item tag to use in recipes
+     * @param ingredient          The ingredient used to make doorknobs of this type
      */
-    MagicDoorknobItem(Item.Properties properties, String typeName, IItemTier tier, ResourceLocation mainTextureLocation, INamedTag<Item> recipeTag) {
+    MagicDoorknobItem(Item.Properties properties, String typeName, IItemTier tier, ResourceLocation mainTextureLocation, Supplier<Ingredient> ingredient) {
         super(properties);
 
         this.typeName = typeName;
         this.tier = tier;
         this.mainTextureLocation = mainTextureLocation;
-        this.recipeTag = recipeTag;
+        this.ingredient = ingredient;
     }
 
     /**
@@ -244,9 +245,9 @@ public class MagicDoorknobItem extends Item {
     }
 
     /**
-     * @return The item tag for use in recipes
+     * @return The ingredient used to make doorknobs of this type
      */
-    public INamedTag<Item> getRecipeTag() {
-        return recipeTag;
+    public Ingredient getIngredient() {
+        return ingredient.get();
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects {
     }
 
     dependencies {
-        minecraft "net.minecraftforge:forge:1.16.1-32.0.69"
+        minecraft "net.minecraftforge:forge:1.16.1-32.0.44"
 
         implementation 'com.google.code.findbugs:jsr305:3.0.2'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects {
     }
 
     dependencies {
-        minecraft "net.minecraftforge:forge:1.16.1-32.0.44"
+        minecraft "net.minecraftforge:forge:1.16.1-32.0.69"
 
         implementation 'com.google.code.findbugs:jsr305:3.0.2'
     }


### PR DESCRIPTION
Also replace tags by ingredient suppliers when registering the doorknobs.

Interestingly Netherite doorknobs are still inferior to gold when it comes to distance.