### PR TITLE
Make Curseforge release use the same build number as the build itself

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,10 @@ jobs:
             TAG_BUILD="$(echo "$CIRCLE_TAG" | sed -E 's/-[0-9.-]+$//' | sed -E 's/(^|-)([^-])/\U\2/g')"
             TAG_VERSION="$(echo "$CIRCLE_TAG" | sed -E 's/[^0-9]+//')"
             PROJECT_ID="$(jq -r .projectId $TAG_BUILD/curseforge.json)"
-            METADATA="$(jq -n '{"changelog": $ARGS.positional[0], "changelogType": "markdown", "displayName": $ARGS.positional[1], "gameVersions": [6756, 7498, 4458], "releaseType": "release"}' --args "$DESCRIPTION" "v$TAG_VERSION.$CIRCLE_BUILD_NUM")"
             FILE="$(ls /tmp/workspace/libs/*.jar | grep -v sources | head -n 1)"
+            # Use the build number on the JAR to prevent confusion.
+            ORIGINAL_BUILD_NUM="$(echo "$FILE" | sed -E 's/^.*\.([0-9]+)\.jar$/\1/')"
+            METADATA="$(jq -n '{"changelog": $ARGS.positional[0], "changelogType": "markdown", "displayName": $ARGS.positional[1], "gameVersions": [6756, 7498, 4458], "releaseType": "release"}' --args "$DESCRIPTION" "v$TAG_VERSION.$ORIGINAL_BUILD_NUM")"
             curl -XPOST "https://minecraft.curseforge.com/api/projects/$PROJECT_ID/upload-file" -F "file=@$FILE" -F "metadata=$METADATA" -H "X-Api-Token: $CURSEFORGE_TOKEN"
 workflows:
   version: 2


### PR DESCRIPTION
Fixes #65 