### PR TITLE
Switch to my own base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             - libs/*.jar
   release-github:
     docker:
-      - image: gableroux/github-release:v1.0.2
+      - image: tboshoven/ci:v1
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -61,12 +61,8 @@ jobs:
             done
   release-curseforge:
     docker:
-      - image: gableroux/github-release:v1.0.2
+      - image: tboshoven/ci:v1
     steps:
-      - run:
-          name: Install requirements
-          # Need curl for the API request and GNU sed for \U support
-          command: apk add -v --no-progress curl git sed
       - checkout
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
The one I was using was outdated and used a deprecated GitHub auth mechanism.