### PR TITLE
Refactor modifiers to store the items that were used to create them

### DIFF
--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ArmorMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ArmorMagicMirrorBlockEntityModifier.java
@@ -44,7 +44,7 @@ import java.util.function.Supplier;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class ArmorMagicMirrorBlockEntityModifier extends MagicMirrorBlockEntityModifier {
+public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlockEntityModifier {
     /**
      * The number of ticks this modifier needs to cool down.
      */
@@ -64,8 +64,18 @@ public class ArmorMagicMirrorBlockEntityModifier extends MagicMirrorBlockEntityM
     /**
      * @param modifier The modifier that applied this object to the block entity.
      */
-    public ArmorMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier) {
-        super(modifier);
+    public ArmorMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, ItemStack item) {
+        super(modifier, item);
+    }
+
+    public ArmorMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, CompoundTag nbt) {
+        super(modifier, nbt);
+        replacementArmor.read(nbt);
+    }
+
+    @Override
+    protected ItemStack getItemStackOldNbt(CompoundTag nbt) {
+        return new ItemStack(Items.ARMOR_STAND);
     }
 
     @Override
@@ -74,14 +84,8 @@ public class ArmorMagicMirrorBlockEntityModifier extends MagicMirrorBlockEntityM
     }
 
     @Override
-    public void read(CompoundTag nbt) {
-        super.read(nbt);
-        replacementArmor.read(nbt);
-    }
-
-    @Override
     public void remove(Level world, BlockPos pos) {
-        Containers.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), new ItemStack(Items.ARMOR_STAND));
+        super.remove(world, pos);
         replacementArmor.spawn(world, pos);
     }
 

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/BannerMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/BannerMagicMirrorBlockEntityModifier.java
@@ -7,19 +7,18 @@ import com.tomboshoven.minecraft.magicmirror.reflection.Reflection;
 import com.tomboshoven.minecraft.magicmirror.reflection.modifiers.BannerReflectionModifier;
 import com.tomboshoven.minecraft.magicmirror.reflection.modifiers.BannerReflectionModifierClient;
 import net.minecraft.MethodsReturnNonnullByDefault;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BannerItem;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BannerPattern;
 import net.minecraft.world.level.block.entity.BannerPatterns;
@@ -35,101 +34,72 @@ import java.util.Optional;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class BannerMagicMirrorBlockEntityModifier extends MagicMirrorBlockEntityModifier {
-    /**
-     * The initial color of the banner (before any patterns are applied)
-     */
-    private DyeColor baseColor = DyeColor.BLACK;
-    /**
-     * The banner NBT tag, stored here for removal.
-     */
-    @Nullable
-    private CompoundTag bannerNBT;
-    /**
-     * The banner name.
-     */
-    @Nullable
-    private Component name;
+public class BannerMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlockEntityModifier {
     /**
      * The object that modifies the reflection in the mirror to show the banner in the background.
      */
     @Nullable
     private BannerReflectionModifier reflectionModifier;
 
-    public BannerMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier) {
-        super(modifier);
+    public BannerMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, ItemStack item) {
+        super(modifier, item);
     }
 
-    public BannerMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, DyeColor baseColor, @Nullable CompoundTag bannerNBT, @Nullable Component name) {
-        super(modifier);
-        this.baseColor = baseColor;
-        this.bannerNBT = bannerNBT != null ? bannerNBT.copy() : null;
-        this.name = name;
+    public BannerMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, CompoundTag nbt) {
+        super(modifier, nbt);
     }
 
     @Override
-    public void remove(Level world, BlockPos pos) {
+    protected ItemStack getItemStackOldNbt(CompoundTag nbt) {
+        DyeColor baseColor = DyeColor.byId(nbt.getInt("BannerColor"));
+        CompoundTag bannerData = nbt.getCompound("BannerData");
+        Component name = Component.Serializer.fromJson(nbt.getString("BannerName"));
+
         // BannerBlock.forColor is client-only.
         // Let's do a super-ugly workaround.
         // This will cause issues if dye colors are ever made extensible.
         Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(String.format("minecraft:%s_banner", baseColor.getName())));
-        ItemStack itemStack = new ItemStack(block);
-        if (bannerNBT != null) {
-            itemStack.getOrCreateTag().put("BlockEntityTag", bannerNBT);
+        if (block == null) {
+            return super.getItemStackOldNbt(nbt);
         }
+        ItemStack itemStack = new ItemStack(block);
+        itemStack.getOrCreateTag().put("BlockEntityTag", bannerData);
         if (name != null) {
             itemStack.setHoverName(name);
         }
-        Containers.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), itemStack);
-    }
-
-    @Override
-    public CompoundTag write(CompoundTag nbt) {
-        super.write(nbt);
-        nbt.putInt("BannerColor", baseColor.getId());
-        if (bannerNBT != null) {
-            nbt.put("BannerData", bannerNBT.copy());
-        }
-        nbt.putString("BannerName", Component.Serializer.toJson(name));
-        return nbt;
-    }
-
-    @Override
-    public void read(CompoundTag nbt) {
-        super.read(nbt);
-        baseColor = DyeColor.byId(nbt.getInt("BannerColor"));
-        CompoundTag bannerData = nbt.getCompound("BannerData");
-        if (!bannerData.isEmpty()) {
-            bannerNBT = bannerData.copy();
-        }
-        name = Component.Serializer.fromJson(nbt.getString("BannerName"));
+        return itemStack;
     }
 
     @Override
     public void activate(MagicMirrorCoreBlockEntity blockEntity) {
         Reflection reflection = blockEntity.getReflection();
         if (reflection != null) {
-            List<Pair<Holder<BannerPattern>, DyeColor>> patternList = Lists.newArrayList();
-            Optional<? extends Holder<BannerPattern>> base = BuiltInRegistries.BANNER_PATTERN.getHolder(BannerPatterns.BASE);
-            base.ifPresent(bannerPatternHolder -> patternList.add(Pair.of(bannerPatternHolder, baseColor)));
-            if (bannerNBT != null) {
-                // Get the patterns from the NBT data
-                ListTag patterns = bannerNBT.getList("Patterns", 10);
-                int size = patterns.size();
-                for (int i = 0; i < size; ++i) {
-                    CompoundTag pattern = patterns.getCompound(i);
-                    String patternHash = pattern.getString("Pattern");
-                    Holder<BannerPattern> bannerPattern = BannerPattern.byHash(patternHash);
-                    if (bannerPattern != null) {
-                        DyeColor bannerPatternColor = DyeColor.byId(pattern.getInt("Color"));
-                        patternList.add(Pair.of(bannerPattern, bannerPatternColor));
+            if (item.getItem() instanceof BannerItem bannerItem) {
+                DyeColor baseColor = bannerItem.getColor();
+                CompoundTag bannerNBT = BlockItem.getBlockEntityData(item);
+
+                List<Pair<Holder<BannerPattern>, DyeColor>> patternList = Lists.newArrayList();
+                Optional<? extends Holder<BannerPattern>> base = BuiltInRegistries.BANNER_PATTERN.getHolder(BannerPatterns.BASE);
+                base.ifPresent(bannerPatternHolder -> patternList.add(Pair.of(bannerPatternHolder, baseColor)));
+                if (bannerNBT != null) {
+                    // Get the patterns from the NBT data
+                    ListTag patterns = bannerNBT.getList("Patterns", 10);
+                    int size = patterns.size();
+                    for (int i = 0; i < size; ++i) {
+                        CompoundTag pattern = patterns.getCompound(i);
+                        String patternHash = pattern.getString("Pattern");
+                        Holder<BannerPattern> bannerPattern = BannerPattern.byHash(patternHash);
+                        if (bannerPattern != null) {
+                            DyeColor bannerPatternColor = DyeColor.byId(pattern.getInt("Color"));
+                            patternList.add(Pair.of(bannerPattern, bannerPatternColor));
+                        }
                     }
                 }
+
+                reflectionModifier = createReflectionModifier(patternList);
+
+                reflection.addModifier(reflectionModifier);
             }
-
-            reflectionModifier = createReflectionModifier(patternList);
-
-            reflection.addModifier(reflectionModifier);
         }
     }
 

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
@@ -6,22 +6,22 @@ import com.tomboshoven.minecraft.magicmirror.reflection.Reflection;
 import com.tomboshoven.minecraft.magicmirror.reflection.modifiers.CreatureReflectionModifier;
 import com.tomboshoven.minecraft.magicmirror.reflection.modifiers.CreatureReflectionModifierClient;
 import net.minecraft.MethodsReturnNonnullByDefault;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.Containers;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.Level;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class CreatureMagicMirrorBlockEntityModifier extends MagicMirrorBlockEntityModifier {
+public class CreatureMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlockEntityModifier {
     /**
      * The entity type to use for the reflection.
      */
@@ -33,17 +33,25 @@ public class CreatureMagicMirrorBlockEntityModifier extends MagicMirrorBlockEnti
     @Nullable
     private CreatureReflectionModifier reflectionModifier;
 
-    /**
-     * @param modifier The modifier that applied this object to the block entity.
-     */
-    public CreatureMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, EntityType<?> entityType) {
-        super(modifier);
+    public CreatureMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, ItemStack item, EntityType<?> entityType) {
+        super(modifier, item);
+        this.entityType = entityType;
+    }
+
+    public CreatureMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, CompoundTag nbt) {
+        super(modifier, nbt);
+        ResourceLocation entityTypeKey = new ResourceLocation(nbt.getString("EntityType"));
+        EntityType<?> entityType = ForgeRegistries.ENTITY_TYPES.getValue(entityTypeKey);
+        if (entityType == null) {
+            // Backward compatibility
+            entityType = EntityType.SKELETON;
+        }
         this.entityType = entityType;
     }
 
     @Override
-    public void remove(Level world, BlockPos pos) {
-        Containers.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), new ItemStack(Items.SKELETON_SKULL, 1));
+    protected ItemStack getItemStackOldNbt(CompoundTag nbt) {
+        return new ItemStack(Items.SKELETON_SKULL);
     }
 
     @Override

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
@@ -1,6 +1,7 @@
 package com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers;
 
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.MagicMirrorCoreBlockEntity;
+import com.tomboshoven.minecraft.magicmirror.blocks.modifiers.CreatureMagicMirrorModifier;
 import com.tomboshoven.minecraft.magicmirror.blocks.modifiers.MagicMirrorModifier;
 import com.tomboshoven.minecraft.magicmirror.reflection.Reflection;
 import com.tomboshoven.minecraft.magicmirror.reflection.modifiers.CreatureReflectionModifier;
@@ -40,11 +41,17 @@ public class CreatureMagicMirrorBlockEntityModifier extends ItemBasedMagicMirror
 
     public CreatureMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, CompoundTag nbt) {
         super(modifier, nbt);
-        ResourceLocation entityTypeKey = new ResourceLocation(nbt.getString("EntityType"));
-        EntityType<?> entityType = ForgeRegistries.ENTITY_TYPES.getValue(entityTypeKey);
-        if (entityType == null) {
+        EntityType<?> entityType = null;
+        if (nbt.contains("EntityType", 8)) {
+            ResourceLocation entityTypeKey = new ResourceLocation(nbt.getString("EntityType"));
+            // Extra check to make sure we're not getting the default
+            if (ForgeRegistries.ENTITY_TYPES.containsKey(entityTypeKey)) {
+                entityType = ForgeRegistries.ENTITY_TYPES.getValue(entityTypeKey);
+            }
+        }
+        if (entityType == null || !CreatureMagicMirrorModifier.isSupportedEntityType(entityType)) {
             // Backward compatibility
-            entityType = EntityType.SKELETON;
+            entityType = CreatureMagicMirrorModifier.getDefaultEntityType();
         }
         this.entityType = entityType;
     }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
@@ -55,6 +55,16 @@ public class CreatureMagicMirrorBlockEntityModifier extends ItemBasedMagicMirror
     }
 
     @Override
+    public CompoundTag write(CompoundTag nbt) {
+        super.write(nbt);
+        ResourceLocation entityTypeKey = ForgeRegistries.ENTITY_TYPES.getKey(entityType);
+        if (entityTypeKey != null) {
+            nbt.putString("EntityType", entityTypeKey.toString());
+        }
+        return nbt;
+    }
+
+    @Override
     public void activate(MagicMirrorCoreBlockEntity blockEntity) {
         Reflection reflection = blockEntity.getReflection();
         if (reflection != null) {

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ItemBasedMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ItemBasedMagicMirrorBlockEntityModifier.java
@@ -1,0 +1,60 @@
+package com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers;
+
+import com.tomboshoven.minecraft.magicmirror.blocks.modifiers.MagicMirrorModifier;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Containers;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+public abstract class ItemBasedMagicMirrorBlockEntityModifier extends MagicMirrorBlockEntityModifier {
+    ItemStack item;
+
+    /**
+     * @param item The item that went into the mirror to create this modifier.
+     */
+    public ItemBasedMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, ItemStack item) {
+        super(modifier);
+        this.item = item;
+    }
+
+    public ItemBasedMagicMirrorBlockEntityModifier(MagicMirrorModifier modifier, CompoundTag nbt) {
+        super(modifier);
+        CompoundTag itemCompound = nbt.getCompound("Item");
+        if (itemCompound.isEmpty()) {
+            item = getItemStackOldNbt(nbt);
+        }
+        else {
+            item = ItemStack.of(itemCompound);
+        }
+    }
+
+    /**
+     * Reconstruct the item stack from old NBT compounds, which kept track of things separately.
+     * This should be safe to remove over time.
+     *
+     * @param nbt The NBT compound to attempt to reconstruct the item stack for.
+     * @return the reconstructed item stack.
+     */
+    protected ItemStack getItemStackOldNbt(CompoundTag nbt) {
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public CompoundTag write(CompoundTag nbt) {
+        super.write(nbt);
+        CompoundTag itemCompound = item.serializeNBT();
+        nbt.put("Item", itemCompound);
+        return nbt;
+    }
+
+    @Override
+    public void remove(Level world, BlockPos pos) {
+        Containers.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), this.item);
+    }
+}

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/MagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/MagicMirrorBlockEntityModifier.java
@@ -54,14 +54,6 @@ public abstract class MagicMirrorBlockEntityModifier {
     }
 
     /**
-     * Load modifier data from an NBT tag.
-     *
-     * @param nbt The NBT tag compound to read from.
-     */
-    public void read(CompoundTag nbt) {
-    }
-
-    /**
      * Called when the block entity is removed.
      * Can be used for things like spawning contained items back into the world.
      *

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/ArmorMagicMirrorModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/ArmorMagicMirrorModifier.java
@@ -4,11 +4,9 @@ import com.tomboshoven.minecraft.magicmirror.blocks.entities.MagicMirrorCoreBloc
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers.ArmorMagicMirrorBlockEntityModifier;
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers.MagicMirrorBlockEntityModifier;
 import net.minecraft.MethodsReturnNonnullByDefault;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.Level;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -36,13 +34,11 @@ public class ArmorMagicMirrorModifier extends MagicMirrorModifier {
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(CompoundTag nbt) {
-        MagicMirrorBlockEntityModifier teModifier = new ArmorMagicMirrorBlockEntityModifier(this);
-        teModifier.read(nbt);
-        return teModifier;
+        return new ArmorMagicMirrorBlockEntityModifier(this, nbt);
     }
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(ItemStack usedItem) {
-        return new ArmorMagicMirrorBlockEntityModifier(this);
+        return new ArmorMagicMirrorBlockEntityModifier(this, usedItem.split(1));
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/BannerMagicMirrorModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/BannerMagicMirrorModifier.java
@@ -4,13 +4,9 @@ import com.tomboshoven.minecraft.magicmirror.blocks.entities.MagicMirrorCoreBloc
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers.BannerMagicMirrorBlockEntityModifier;
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers.MagicMirrorBlockEntityModifier;
 import net.minecraft.MethodsReturnNonnullByDefault;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.BannerItem;
-import net.minecraft.world.item.DyeColor;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -38,20 +34,11 @@ public class BannerMagicMirrorModifier extends MagicMirrorModifier {
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(CompoundTag nbt) {
-        MagicMirrorBlockEntityModifier teModifier = new BannerMagicMirrorBlockEntityModifier(this);
-        teModifier.read(nbt);
-        return teModifier;
+        return new BannerMagicMirrorBlockEntityModifier(this, nbt);
     }
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(ItemStack usedItem) {
-        Item bannerType = usedItem.getItem();
-        DyeColor bannerColor = bannerType instanceof BannerItem ? ((BannerItem) bannerType).getColor() : DyeColor.BLACK;
-        CompoundTag bannerTag = usedItem.getTag();
-        if (bannerTag != null) {
-            // Get the block tag instead of the item stack tag
-            bannerTag = bannerTag.getCompound("BlockEntityTag");
-        }
-        return new BannerMagicMirrorBlockEntityModifier(this, bannerColor, bannerTag, usedItem.hasCustomHoverName() ? usedItem.getHoverName() : null);
+        return new BannerMagicMirrorBlockEntityModifier(this, usedItem.split(1));
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/CreatureMagicMirrorModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/CreatureMagicMirrorModifier.java
@@ -25,7 +25,29 @@ public class CreatureMagicMirrorModifier extends MagicMirrorModifier {
      */
     private static boolean isSupportedSkull(ItemStack item) {
         // Only support skeleton skulls for now
-        return item.getItem() == Items.SKELETON_SKULL && Items.SKELETON_SKULL.getDamage(item) == 0;
+        return item.getItem() == Items.SKELETON_SKULL;
+    }
+
+    /**
+     * Check whether the given entity type is supported by the mirror.
+     * This can be used as a safety check to prevent crashes upon bad NBT data.
+     *
+     * @param entityType The entity type to check.
+     * @return whether the provided entity type is supported by the modifier.
+     */
+    public static boolean isSupportedEntityType(EntityType<?> entityType) {
+        // Only skeletons are supported for now
+        return entityType == EntityType.SKELETON;
+    }
+
+    /**
+     * Get the default entity type to use when we have no information.
+     * This can be used for recovery upon bad data.
+     *
+     * @return the entity type to use when we don't have the required information.
+     */
+    public static EntityType<?> getDefaultEntityType() {
+        return EntityType.SKELETON;
     }
 
     @Override
@@ -45,6 +67,8 @@ public class CreatureMagicMirrorModifier extends MagicMirrorModifier {
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(ItemStack usedItem) {
-        return new CreatureMagicMirrorBlockEntityModifier(this, usedItem.split(1), EntityType.SKELETON);
+        // Only one entity type is supported for now
+        EntityType<?> entityType = getDefaultEntityType();
+        return new CreatureMagicMirrorBlockEntityModifier(this, usedItem.split(1), entityType);
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/CreatureMagicMirrorModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/CreatureMagicMirrorModifier.java
@@ -45,6 +45,6 @@ public class CreatureMagicMirrorModifier extends MagicMirrorModifier {
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(ItemStack usedItem) {
-        return new CreatureMagicMirrorBlockEntityModifier(this, usedItem, EntityType.SKELETON);
+        return new CreatureMagicMirrorBlockEntityModifier(this, usedItem.split(1), EntityType.SKELETON);
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/CreatureMagicMirrorModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/CreatureMagicMirrorModifier.java
@@ -4,12 +4,10 @@ import com.tomboshoven.minecraft.magicmirror.blocks.entities.MagicMirrorCoreBloc
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers.CreatureMagicMirrorBlockEntityModifier;
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.modifiers.MagicMirrorBlockEntityModifier;
 import net.minecraft.MethodsReturnNonnullByDefault;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.Level;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -42,13 +40,11 @@ public class CreatureMagicMirrorModifier extends MagicMirrorModifier {
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(CompoundTag nbt) {
-        MagicMirrorBlockEntityModifier teModifier = new CreatureMagicMirrorBlockEntityModifier(this, EntityType.SKELETON);
-        teModifier.read(nbt);
-        return teModifier;
+        return new CreatureMagicMirrorBlockEntityModifier(this, nbt);
     }
 
     @Override
     MagicMirrorBlockEntityModifier createBlockEntityModifier(ItemStack usedItem) {
-        return new CreatureMagicMirrorBlockEntityModifier(this, EntityType.SKELETON);
+        return new CreatureMagicMirrorBlockEntityModifier(this, usedItem, EntityType.SKELETON);
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/MagicMirrorModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/modifiers/MagicMirrorModifier.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import javax.annotation.Nullable;
@@ -115,7 +114,6 @@ public abstract class MagicMirrorModifier {
      */
     public void apply(MagicMirrorCoreBlockEntity blockEntity, ItemStack heldItem) {
         blockEntity.addModifier(createBlockEntityModifier(heldItem));
-        heldItem.shrink(1);
     }
 
     /**


### PR DESCRIPTION
Since basically all modifiers are based on some kind of item, we should simply use that.
While this does require maintaining a backward-compatible fallback, the overall approach is so much simpler that it's worth it.

This change should also fix some issues where items could be stripped of data.