### PR TITLE
Simplify server-client code

### DIFF
--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/MagicDoorknobMod.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/MagicDoorknobMod.java
@@ -9,10 +9,10 @@ import com.tomboshoven.minecraft.magicdoorknob.items.Items;
 import com.tomboshoven.minecraft.magicdoorknob.modelloaders.ModelLoaders;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 
 @Mod(MagicDoorknobMod.MOD_ID)
 public final class MagicDoorknobMod {
@@ -26,9 +26,16 @@ public final class MagicDoorknobMod {
         Items.register(modEventBus);
         BlockEntities.register(modEventBus);
 
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            ClientEvents.init();
+        }
+    }
+
+    static class ClientEvents {
+        static void init() {
+            IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
             BlockColorHandlers.register(modEventBus);
             ModelLoaders.register(modEventBus);
-        });
+        }
     }
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/BlockColorHandlers.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/BlockColorHandlers.java
@@ -3,15 +3,12 @@ package com.tomboshoven.minecraft.magicdoorknob.blocks.colorhandlers;
 import com.tomboshoven.minecraft.magicdoorknob.blocks.Blocks;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.block.BlockColors;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 
 /**
  * Class for registering color handlers in the clients.
  */
-@OnlyIn(Dist.CLIENT)
 public final class BlockColorHandlers {
     private BlockColorHandlers() {
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/DoorwayBlockColorHandler.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/DoorwayBlockColorHandler.java
@@ -8,15 +8,12 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 import javax.annotation.Nullable;
 
 /**
  * Handler for giving doorways more or less the color they should be.
  */
-@OnlyIn(Dist.CLIENT)
 class DoorwayBlockColorHandler implements BlockColor {
     @Override
     public int getColor(BlockState state, @Nullable BlockAndTintGetter worldIn, @Nullable BlockPos pos, int tintIndex) {

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
@@ -20,8 +20,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.CompositeModel;
 import net.minecraftforge.client.model.data.IModelData;
 
@@ -90,7 +88,6 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
         return new ClientboundBlockEntityDataPacket(getBlockPos(), 1, getUpdateTag());
     }
 
-    @OnlyIn(Dist.CLIENT)
     @Override
     public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
         readInternal(pkt.getTag());
@@ -98,7 +95,6 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
     public IModelData getModelData() {
         Minecraft minecraft = Minecraft.getInstance();
         BlockModelShaper blockModelShapes = minecraft.getBlockRenderer().getBlockModelShaper();

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/MagicDoorknobItem.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/MagicDoorknobItem.java
@@ -25,8 +25,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.TierSortingRegistry;
 
 import java.util.function.Supplier;
@@ -223,7 +221,6 @@ public class MagicDoorknobItem extends Item {
     /**
      * @return The location of the main texture of the doorknob
      */
-    @OnlyIn(Dist.CLIENT)
     public Material getMainMaterial() {
         return new Material(InventoryMenu.BLOCK_ATLAS, mainTextureLocation);
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/ModelLoaders.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/ModelLoaders.java
@@ -7,8 +7,6 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.InventoryMenu;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -18,7 +16,6 @@ import static com.tomboshoven.minecraft.magicdoorknob.MagicDoorknobMod.MOD_ID;
 /**
  * Collection of custom model loaders.
  */
-@OnlyIn(Dist.CLIENT)
 public final class ModelLoaders {
     private ModelLoaders() {
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/IItemStackTextureMapperProvider.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/IItemStackTextureMapperProvider.java
@@ -1,8 +1,6 @@
 package com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Interface for providing texture mappers for item stacks.
@@ -12,6 +10,5 @@ public interface IItemStackTextureMapperProvider {
      * @param stack The item stack to provide a texture mapper for
      * @return A texture mapper
      */
-    @OnlyIn(Dist.CLIENT)
     ITextureMapper getTextureMapper(ItemStack stack);
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ITextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ITextureMapper.java
@@ -2,8 +2,6 @@ package com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured;
 
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.data.IModelData;
 
 import javax.annotation.Nullable;
@@ -11,7 +9,6 @@ import javax.annotation.Nullable;
 /**
  * An interface for getting a texture location for a property.
  */
-@OnlyIn(Dist.CLIENT)
 public interface ITextureMapper {
     /**
      * @param spriteToMap The property to get the texture location for

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelDataTextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelDataTextureMapper.java
@@ -5,8 +5,6 @@ import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.client.model.data.ModelProperty;
 
@@ -15,7 +13,6 @@ import javax.annotation.Nullable;
 /**
  * Extract the texture location from extra model data.
  */
-@OnlyIn(Dist.CLIENT)
 class ModelDataTextureMapper implements ITextureMapper {
     @Override
     public Material mapSprite(PropertySprite spriteToMap, @Nullable BlockState blockState, @Nullable IModelData extraData) {

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/PropertySprite.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/PropertySprite.java
@@ -7,14 +7,11 @@ import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.metadata.animation.AnimationMetadataSection;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * A sprite that does not link to a texture.
  * Instead, it describes a property that allows others to provide the texture (see ITextureMapper).
  */
-@OnlyIn(Dist.CLIENT)
 public class PropertySprite extends TextureAtlasSprite {
     private static final TextureAtlas ATLAS_TEXTURE = new TextureAtlas(new ResourceLocation(MagicDoorknobMod.MOD_ID, "property_texture_atlas"));
     private static final NativeImage NATIVE_IMAGE = new NativeImage(1, 1, false);

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedBakedModel.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedBakedModel.java
@@ -15,8 +15,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.BakedModelWrapper;
 import net.minecraftforge.client.model.data.EmptyModelData;
 import net.minecraftforge.client.model.data.IModelData;
@@ -31,7 +29,6 @@ import java.util.stream.Collectors;
 /**
  * A baked model that fills in the texture properties dynamically.
  */
-@OnlyIn(Dist.CLIENT)
 class TexturedBakedModel<T extends BakedModel> extends BakedModelWrapper<T> {
     // The baked texture getter
     private final Function<? super Material, ? extends TextureAtlasSprite> bakedTextureGetter;

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedModelGeometry.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedModelGeometry.java
@@ -10,8 +10,6 @@ import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.UnbakedModel;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.IModelConfiguration;
 import net.minecraftforge.client.model.geometry.IModelGeometry;
 
@@ -25,7 +23,6 @@ import static com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured.Text
 /**
  * A model that has dynamic properties that are used to determine textures at runtime.
  */
-@OnlyIn(Dist.CLIENT)
 public class TexturedModelGeometry implements IModelGeometry<TexturedModelGeometry> {
     // The extra textures to include with this model; used to enable textures that are not already present in the game
     private final Set<? extends Material> extraTextures;

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedModelLoader.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedModelLoader.java
@@ -6,8 +6,6 @@ import com.google.gson.JsonObject;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.IModelLoader;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.client.model.geometry.IModelGeometry;
@@ -17,7 +15,6 @@ import java.util.Set;
 /**
  * A model loader that deals with dynamic properties that are used to determine textures at runtime.
  */
-@OnlyIn(Dist.CLIENT)
 public class TexturedModelLoader implements IModelLoader<TexturedModelGeometry> {
     // The namespace of the properties; used in model definitions
     public static final String PROPERTY_NAMESPACE = "property";

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/MagicMirrorMod.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/MagicMirrorMod.java
@@ -15,9 +15,9 @@ import com.tomboshoven.minecraft.magicmirror.renderers.Renderers;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -34,10 +34,6 @@ public final class MagicMirrorMod {
         DataGenerators.register(modEventBus);
         Items.register(modEventBus);
         BlockEntities.register(modEventBus);
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
-            Renderers.register(modEventBus);
-            MinecraftForge.EVENT_BUS.register(ReflectionClientUpdater.class);
-        });
 
         // Register packets
         Network.registerMessages();
@@ -48,5 +44,17 @@ public final class MagicMirrorMod {
         MagicMirrorModifier.register(new ArmorMagicMirrorModifier());
         MagicMirrorModifier.register(new BannerMagicMirrorModifier());
         MagicMirrorModifier.register(new CreatureMagicMirrorModifier());
+
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            ClientEvents.init();
+        }
+    }
+
+    static class ClientEvents {
+        static void init() {
+            IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+            Renderers.register(modEventBus);
+            MinecraftForge.EVENT_BUS.register(ReflectionClientUpdater.class);
+        }
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/MagicMirrorCoreBlock.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/MagicMirrorCoreBlock.java
@@ -18,8 +18,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fmllegacy.network.NetworkEvent;
 
 import javax.annotation.Nullable;
@@ -159,7 +157,7 @@ public class MagicMirrorCoreBlock extends MagicMirrorActiveBlock {
      */
     public static void onMessageAttachModifier(MessageAttachModifier message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 BlockEntity blockEntity = world.getBlockEntity(message.mirrorPos);
@@ -173,7 +171,7 @@ public class MagicMirrorCoreBlock extends MagicMirrorActiveBlock {
                     world.playLocalSound(message.mirrorPos, SoundEvents.ARMOR_EQUIP_GENERIC, SoundSource.BLOCKS, .6f, .6f, true);
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
@@ -18,8 +18,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.util.FakePlayer;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -45,7 +46,7 @@ public class MagicMirrorCoreBlockEntity extends BlockEntity {
     public MagicMirrorCoreBlockEntity(BlockPos pos, BlockState state) {
         super(BlockEntities.MAGIC_MIRROR_CORE.get(), pos, state);
 
-        reflection = DistExecutor.unsafeRunForDist(() -> ReflectionClient::new, () -> Reflection::new);
+        reflection = FMLEnvironment.dist == Dist.CLIENT ? new ReflectionClient() : new Reflection();
     }
 
     /**

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
@@ -18,8 +18,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fml.DistExecutor;
 
@@ -229,7 +227,6 @@ public class MagicMirrorCoreBlockEntity extends BlockEntity {
         return new ClientboundBlockEntityDataPacket(getBlockPos(), 1, getUpdateTag());
     }
 
-    @OnlyIn(Dist.CLIENT)
     @Override
     public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
         readInternal(pkt.getTag());

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ArmorMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ArmorMagicMirrorBlockEntityModifier.java
@@ -32,7 +32,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.fmllegacy.network.NetworkEvent;
 import net.minecraftforge.fmllegacy.network.PacketDistributor;
 
@@ -95,10 +95,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
     }
 
     private ArmorReflectionModifier createReflectionModifier() {
-        return DistExecutor.runForDist(
-                () -> () -> new ArmorReflectionModifierClient(replacementArmor),
-                () -> () -> new ArmorReflectionModifier(replacementArmor)
-        );
+        return FMLEnvironment.dist == Dist.CLIENT ? new ArmorReflectionModifierClient(replacementArmor) : new ArmorReflectionModifier(replacementArmor);
     }
 
     @Override
@@ -454,7 +451,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
      */
     public static void onMessageEquip(MessageEquip message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 BlockEntity te = world.getBlockEntity(message.mirrorPos);
@@ -467,7 +464,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
                     world.playLocalSound(message.mirrorPos, item.getMaterial().getEquipSound(), SoundSource.BLOCKS, 1, 1, false);
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 
@@ -476,7 +473,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
      */
     public static void onMessageSwapMirror(MessageSwapMirror message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 BlockEntity te = world.getBlockEntity(message.mirrorPos);
@@ -486,7 +483,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
                             .ifPresent(modifier -> message.armor.swap((ArmorMagicMirrorBlockEntityModifier) modifier));
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 
@@ -495,7 +492,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
      */
     public static void onMessageSwapPlayer(MessageSwapPlayer message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 Entity entity = world.getEntity(message.entityId);
@@ -518,7 +515,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
                     }
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/BannerMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/BannerMagicMirrorBlockEntityModifier.java
@@ -17,7 +17,8 @@ import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BannerPattern;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -96,10 +97,7 @@ public class BannerMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBl
     }
 
     private static BannerReflectionModifier createReflectionModifier(List<? extends Pair<BannerPattern, DyeColor>> patternList) {
-        return DistExecutor.runForDist(
-                () -> () -> new BannerReflectionModifierClient(patternList),
-                () -> () -> new BannerReflectionModifier(patternList)
-        );
+        return FMLEnvironment.dist == Dist.CLIENT ? new BannerReflectionModifierClient(patternList) : new BannerReflectionModifier(patternList);
     }
 
     @Override

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
@@ -13,7 +13,8 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nullable;
@@ -77,10 +78,7 @@ public class CreatureMagicMirrorBlockEntityModifier extends ItemBasedMagicMirror
     }
 
     private CreatureReflectionModifier createReflectionModifier() {
-        return DistExecutor.runForDist(
-                () -> () -> new CreatureReflectionModifierClient(entityType),
-                () -> () -> new CreatureReflectionModifier(entityType)
-        );
+        return FMLEnvironment.dist == Dist.CLIENT ? new CreatureReflectionModifierClient(entityType) : new CreatureReflectionModifier(entityType);
     }
 
     @Override

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionClient.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionClient.java
@@ -9,8 +9,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 import javax.annotation.Nullable;
 import java.util.Locale;
@@ -19,7 +17,6 @@ import java.util.Locale;
  * Client-side version of the reflection.
  * This version actually renders a reflection.
  */
-@OnlyIn(Dist.CLIENT)
 public class ReflectionClient extends Reflection {
     private static final int TEXTURE_WIDTH = 64;
     private static final int TEXTURE_HEIGHT = 128;

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionTexture.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionTexture.java
@@ -4,15 +4,12 @@ import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.pipeline.TextureTarget;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 import static net.minecraft.client.Minecraft.ON_OSX;
 
 /**
  * Simple wrapper around a render target to a texture, so we can use it with the texture manager.
  */
-@OnlyIn(Dist.CLIENT)
 public class ReflectionTexture extends AbstractTexture {
     /**
      * The frame buffer which is used for rendering the reflection to and subsequently rendering it into the world.

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/renderers/ReflectionRendererBase.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/renderers/ReflectionRendererBase.java
@@ -3,13 +3,10 @@ package com.tomboshoven.minecraft.magicmirror.reflection.renderers;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.world.entity.Entity;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Base class for reflection renderers.
  */
-@OnlyIn(Dist.CLIENT)
 public abstract class ReflectionRendererBase {
     /**
      * @return The entity that is being rendered. This is used for chaining modifiers.

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorCoreRenderer.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorCoreRenderer.java
@@ -6,13 +6,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Renderer for the Magic Mirror block entity.
  */
-@OnlyIn(Dist.CLIENT)
 class BlockEntityMagicMirrorCoreRenderer extends BlockEntityMagicMirrorRendererBase implements BlockEntityRenderer<MagicMirrorCoreBlockEntity> {
     BlockEntityMagicMirrorCoreRenderer(BlockEntityRendererProvider.Context context) {
 

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorPartRenderer.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorPartRenderer.java
@@ -7,13 +7,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Renderer for the Magic Mirror block entity.
  */
-@OnlyIn(Dist.CLIENT)
 class BlockEntityMagicMirrorPartRenderer extends BlockEntityMagicMirrorRendererBase implements BlockEntityRenderer<MagicMirrorPartBlockEntity> {
 
     BlockEntityMagicMirrorPartRenderer(BlockEntityRendererProvider.Context context) {

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/Renderers.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/Renderers.java
@@ -2,8 +2,6 @@ package com.tomboshoven.minecraft.magicmirror.renderers;
 
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.BlockEntities;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
@@ -12,7 +10,6 @@ import net.minecraftforge.eventbus.api.IEventBus;
 /**
  * Manager of all renderers in the mod.
  */
-@OnlyIn(Dist.CLIENT)
 public final class Renderers {
     private Renderers() {
     }


### PR DESCRIPTION
Remove overhead of `OnlyIn` and `DistExecutor`.

Server and client code will be more cleanly isolated in a future iteration.