### PR TITLE
Simplify server-client code

### DIFF
--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/MagicDoorknobMod.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/MagicDoorknobMod.java
@@ -9,10 +9,10 @@ import com.tomboshoven.minecraft.magicdoorknob.items.Items;
 import com.tomboshoven.minecraft.magicdoorknob.modelloaders.ModelLoaders;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 
 @Mod(MagicDoorknobMod.MOD_ID)
 public final class MagicDoorknobMod {
@@ -26,9 +26,16 @@ public final class MagicDoorknobMod {
         Items.register(modEventBus);
         BlockEntities.register(modEventBus);
 
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            ClientEvents.init();
+        }
+    }
+
+    static class ClientEvents {
+        static void init() {
+            IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
             BlockColorHandlers.register(modEventBus);
             ModelLoaders.register(modEventBus);
-        });
+        }
     }
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/BlockColorHandlers.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/BlockColorHandlers.java
@@ -2,15 +2,12 @@ package com.tomboshoven.minecraft.magicdoorknob.blocks.colorhandlers;
 
 import com.tomboshoven.minecraft.magicdoorknob.blocks.Blocks;
 import net.minecraft.client.color.block.BlockColor;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 
 /**
  * Class for registering color handlers in the clients.
  */
-@OnlyIn(Dist.CLIENT)
 public final class BlockColorHandlers {
     private BlockColorHandlers() {
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/DoorwayBlockColorHandler.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/colorhandlers/DoorwayBlockColorHandler.java
@@ -8,15 +8,12 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 import javax.annotation.Nullable;
 
 /**
  * Handler for giving doorways more or less the color they should be.
  */
-@OnlyIn(Dist.CLIENT)
 class DoorwayBlockColorHandler implements BlockColor {
     @Override
     public int getColor(BlockState state, @Nullable BlockAndTintGetter worldIn, @Nullable BlockPos pos, int tintIndex) {

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
@@ -24,8 +24,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.data.ModelData;
 import org.jetbrains.annotations.NotNull;
 
@@ -96,7 +94,6 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
         return ClientboundBlockEntityDataPacket.create(this);
     }
 
-    @OnlyIn(Dist.CLIENT)
     @Override
     public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
         CompoundTag tag = pkt.getTag();
@@ -107,7 +104,6 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
     public @NotNull ModelData getModelData() {
         Minecraft minecraft = Minecraft.getInstance();
         BlockModelShaper blockModelShapes = minecraft.getBlockRenderer().getBlockModelShaper();

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/MagicDoorknobItem.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/items/MagicDoorknobItem.java
@@ -25,8 +25,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.TierSortingRegistry;
 
 import java.util.function.Supplier;
@@ -223,7 +221,6 @@ public class MagicDoorknobItem extends Item {
     /**
      * @return The location of the main texture of the doorknob
      */
-    @OnlyIn(Dist.CLIENT)
     public Material getMainMaterial() {
         return new Material(InventoryMenu.BLOCK_ATLAS, mainTextureLocation);
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/ModelLoaders.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/ModelLoaders.java
@@ -1,15 +1,12 @@
 package com.tomboshoven.minecraft.magicdoorknob.modelloaders;
 
 import com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured.TexturedGeometryLoader;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 
 /**
  * Collection of custom model loaders.
  */
-@OnlyIn(Dist.CLIENT)
 public final class ModelLoaders {
     private ModelLoaders() {
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/IItemStackTextureMapperProvider.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/IItemStackTextureMapperProvider.java
@@ -1,8 +1,6 @@
 package com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Interface for providing texture mappers for item stacks.
@@ -12,6 +10,5 @@ public interface IItemStackTextureMapperProvider {
      * @param stack The item stack to provide a texture mapper for
      * @return A texture mapper
      */
-    @OnlyIn(Dist.CLIENT)
     ITextureMapper getTextureMapper(ItemStack stack);
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ITextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ITextureMapper.java
@@ -2,8 +2,6 @@ package com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured;
 
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.data.ModelData;
 
 import javax.annotation.Nullable;
@@ -11,7 +9,6 @@ import javax.annotation.Nullable;
 /**
  * An interface for getting a texture location for a property.
  */
-@OnlyIn(Dist.CLIENT)
 public interface ITextureMapper {
     /**
      * @param spriteToMap The property to get the texture location for

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelDataTextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/ModelDataTextureMapper.java
@@ -3,8 +3,6 @@ package com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.model.data.ModelProperty;
 
@@ -13,7 +11,6 @@ import javax.annotation.Nullable;
 /**
  * Extract the texture location from extra model data.
  */
-@OnlyIn(Dist.CLIENT)
 class ModelDataTextureMapper implements ITextureMapper {
     @Override
     public @Nullable Material mapSprite(PropertySprite spriteToMap, @Nullable BlockState blockState, @Nullable ModelData extraData) {

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/PropertySprite.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/PropertySprite.java
@@ -6,15 +6,12 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.metadata.animation.AnimationMetadataSection;
 import net.minecraft.client.resources.metadata.animation.FrameSize;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.textures.UnitTextureAtlasSprite;
 
 /**
  * A sprite that does not link to a texture.
  * Instead, it describes a property that allows others to provide the texture (see ITextureMapper).
  */
-@OnlyIn(Dist.CLIENT)
 public class PropertySprite extends TextureAtlasSprite {
     private final ResourceLocation property;
 

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedBakedModel.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedBakedModel.java
@@ -19,8 +19,6 @@ import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.BakedModelWrapper;
 import net.minecraftforge.client.model.data.ModelData;
 import org.jetbrains.annotations.NotNull;
@@ -35,7 +33,6 @@ import java.util.stream.Collectors;
 /**
  * A baked model that fills in the texture properties dynamically.
  */
-@OnlyIn(Dist.CLIENT)
 class TexturedBakedModel<T extends BakedModel> extends BakedModelWrapper<T> {
     // The baked texture getter
     private final Function<? super Material, ? extends TextureAtlasSprite> bakedTextureGetter;

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedGeometryLoader.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedGeometryLoader.java
@@ -4,8 +4,6 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.geometry.GeometryLoaderManager;
 import net.minecraftforge.client.model.geometry.IGeometryLoader;
 import net.minecraftforge.client.model.geometry.IUnbakedGeometry;
@@ -13,7 +11,6 @@ import net.minecraftforge.client.model.geometry.IUnbakedGeometry;
 /**
  * A model loader that deals with dynamic properties that are used to determine textures at runtime.
  */
-@OnlyIn(Dist.CLIENT)
 public class TexturedGeometryLoader implements IGeometryLoader<TexturedUnbakedGeometry> {
     // The namespace of the properties; used in model definitions
     public static final String PROPERTY_NAMESPACE = "property";

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedUnbakedGeometry.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modelloaders/textured/TexturedUnbakedGeometry.java
@@ -8,8 +8,6 @@ import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.UnbakedModel;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.geometry.IGeometryBakingContext;
 import net.minecraftforge.client.model.geometry.IUnbakedGeometry;
 
@@ -20,7 +18,6 @@ import static com.tomboshoven.minecraft.magicdoorknob.modelloaders.textured.Text
 /**
  * A model that has dynamic properties that are used to determine textures at runtime.
  */
-@OnlyIn(Dist.CLIENT)
 public class TexturedUnbakedGeometry implements IUnbakedGeometry<TexturedUnbakedGeometry> {
     // The original model
     private final IUnbakedGeometry<?> originalModelGeometry;

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/MagicMirrorMod.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/MagicMirrorMod.java
@@ -15,9 +15,9 @@ import com.tomboshoven.minecraft.magicmirror.renderers.Renderers;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -34,10 +34,6 @@ public final class MagicMirrorMod {
         DataGenerators.register(modEventBus);
         Items.register(modEventBus);
         BlockEntities.register(modEventBus);
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
-            Renderers.register(modEventBus);
-            MinecraftForge.EVENT_BUS.register(ReflectionClientUpdater.class);
-        });
 
         // Register packets
         Network.registerMessages();
@@ -48,5 +44,17 @@ public final class MagicMirrorMod {
         MagicMirrorModifier.register(new ArmorMagicMirrorModifier());
         MagicMirrorModifier.register(new BannerMagicMirrorModifier());
         MagicMirrorModifier.register(new CreatureMagicMirrorModifier());
+
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            ClientEvents.init();
+        }
+    }
+
+    static class ClientEvents {
+        static void init() {
+            IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+            Renderers.register(modEventBus);
+            MinecraftForge.EVENT_BUS.register(ReflectionClientUpdater.class);
+        }
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/MagicMirrorCoreBlock.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/MagicMirrorCoreBlock.java
@@ -18,8 +18,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.network.NetworkEvent;
 
 import javax.annotation.Nullable;
@@ -158,7 +156,7 @@ public class MagicMirrorCoreBlock extends MagicMirrorActiveBlock {
      */
     public static void onMessageAttachModifier(MessageAttachModifier message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 BlockEntity blockEntity = world.getBlockEntity(message.mirrorPos);
@@ -172,7 +170,7 @@ public class MagicMirrorCoreBlock extends MagicMirrorActiveBlock {
                     world.playLocalSound(message.mirrorPos, SoundEvents.ARMOR_EQUIP_GENERIC, SoundSource.BLOCKS, .6f, .6f, true);
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
@@ -18,8 +18,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fml.DistExecutor;
 
@@ -230,7 +228,6 @@ public class MagicMirrorCoreBlockEntity extends BlockEntity {
         return ClientboundBlockEntityDataPacket.create(this);
     }
 
-    @OnlyIn(Dist.CLIENT)
     @Override
     public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
         CompoundTag tag = pkt.getTag();

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/MagicMirrorCoreBlockEntity.java
@@ -18,8 +18,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.util.FakePlayer;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -45,7 +46,7 @@ public class MagicMirrorCoreBlockEntity extends BlockEntity {
     public MagicMirrorCoreBlockEntity(BlockPos pos, BlockState state) {
         super(BlockEntities.MAGIC_MIRROR_CORE.get(), pos, state);
 
-        reflection = DistExecutor.unsafeRunForDist(() -> ReflectionClient::new, () -> Reflection::new);
+        reflection = FMLEnvironment.dist == Dist.CLIENT ? new ReflectionClient() : new Reflection();
     }
 
     /**

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ArmorMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/ArmorMagicMirrorBlockEntityModifier.java
@@ -32,7 +32,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.PacketDistributor;
 
@@ -95,10 +95,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
     }
 
     private ArmorReflectionModifier createReflectionModifier() {
-        return DistExecutor.runForDist(
-                () -> () -> new ArmorReflectionModifierClient(replacementArmor),
-                () -> () -> new ArmorReflectionModifier(replacementArmor)
-        );
+        return FMLEnvironment.dist == Dist.CLIENT ? new ArmorReflectionModifierClient(replacementArmor) : new ArmorReflectionModifier(replacementArmor);
     }
 
     @Override
@@ -454,7 +451,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
      */
     public static void onMessageEquip(MessageEquip message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 BlockEntity te = world.getBlockEntity(message.mirrorPos);
@@ -467,7 +464,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
                     world.playLocalSound(message.mirrorPos, item.getMaterial().getEquipSound(), SoundSource.BLOCKS, 1, 1, false);
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 
@@ -476,7 +473,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
      */
     public static void onMessageSwapMirror(MessageSwapMirror message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 BlockEntity te = world.getBlockEntity(message.mirrorPos);
@@ -486,7 +483,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
                             .ifPresent(modifier -> message.armor.swap((ArmorMagicMirrorBlockEntityModifier) modifier));
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 
@@ -495,7 +492,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
      */
     public static void onMessageSwapPlayer(MessageSwapPlayer message, Supplier<? extends NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+        ctx.enqueueWork(() -> {
             ClientLevel world = Minecraft.getInstance().level;
             if (world != null) {
                 Entity entity = world.getEntity(message.entityId);
@@ -518,7 +515,7 @@ public class ArmorMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBlo
                     }
                 }
             }
-        }));
+        });
         ctx.setPacketHandled(true);
     }
 }

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/BannerMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/BannerMagicMirrorBlockEntityModifier.java
@@ -21,7 +21,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BannerPattern;
 import net.minecraft.world.level.block.entity.BannerPatterns;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -99,10 +100,7 @@ public class BannerMagicMirrorBlockEntityModifier extends ItemBasedMagicMirrorBl
     }
 
     private static BannerReflectionModifier createReflectionModifier(List<? extends Pair<Holder<BannerPattern>, DyeColor>> patternList) {
-        return DistExecutor.runForDist(
-                () -> () -> new BannerReflectionModifierClient(patternList),
-                () -> () -> new BannerReflectionModifier(patternList)
-        );
+        return FMLEnvironment.dist == Dist.CLIENT ? new BannerReflectionModifierClient(patternList) : new BannerReflectionModifier(patternList);
     }
 
     @Override

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/blocks/entities/modifiers/CreatureMagicMirrorBlockEntityModifier.java
@@ -13,7 +13,8 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nullable;
@@ -77,10 +78,7 @@ public class CreatureMagicMirrorBlockEntityModifier extends ItemBasedMagicMirror
     }
 
     private CreatureReflectionModifier createReflectionModifier() {
-        return DistExecutor.runForDist(
-                () -> () -> new CreatureReflectionModifierClient(entityType),
-                () -> () -> new CreatureReflectionModifier(entityType)
-        );
+        return FMLEnvironment.dist == Dist.CLIENT ? new CreatureReflectionModifierClient(entityType) : new CreatureReflectionModifier(entityType);
     }
 
     @Override

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionClient.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionClient.java
@@ -9,8 +9,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 import javax.annotation.Nullable;
 import java.util.Locale;
@@ -19,7 +17,6 @@ import java.util.Locale;
  * Client-side version of the reflection.
  * This version actually renders a reflection.
  */
-@OnlyIn(Dist.CLIENT)
 public class ReflectionClient extends Reflection {
     private static final int TEXTURE_WIDTH = 64;
     private static final int TEXTURE_HEIGHT = 128;

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionTexture.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/ReflectionTexture.java
@@ -4,15 +4,12 @@ import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.pipeline.TextureTarget;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 import static net.minecraft.client.Minecraft.ON_OSX;
 
 /**
  * Simple wrapper around a render target to a texture, so we can use it with the texture manager.
  */
-@OnlyIn(Dist.CLIENT)
 public class ReflectionTexture extends AbstractTexture {
     /**
      * The frame buffer which is used for rendering the reflection to and subsequently rendering it into the world.

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/renderers/ReflectionRendererBase.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/reflection/renderers/ReflectionRendererBase.java
@@ -3,13 +3,10 @@ package com.tomboshoven.minecraft.magicmirror.reflection.renderers;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.world.entity.Entity;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Base class for reflection renderers.
  */
-@OnlyIn(Dist.CLIENT)
 public abstract class ReflectionRendererBase {
     /**
      * @return The entity that is being rendered. This is used for chaining modifiers.

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorCoreRenderer.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorCoreRenderer.java
@@ -6,13 +6,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Renderer for the Magic Mirror block entity.
  */
-@OnlyIn(Dist.CLIENT)
 class BlockEntityMagicMirrorCoreRenderer extends BlockEntityMagicMirrorRendererBase implements BlockEntityRenderer<MagicMirrorCoreBlockEntity> {
     BlockEntityMagicMirrorCoreRenderer(BlockEntityRendererProvider.Context context) {
 

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorPartRenderer.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/BlockEntityMagicMirrorPartRenderer.java
@@ -7,13 +7,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Renderer for the Magic Mirror block entity.
  */
-@OnlyIn(Dist.CLIENT)
 class BlockEntityMagicMirrorPartRenderer extends BlockEntityMagicMirrorRendererBase implements BlockEntityRenderer<MagicMirrorPartBlockEntity> {
 
     BlockEntityMagicMirrorPartRenderer(BlockEntityRendererProvider.Context context) {

--- a/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/Renderers.java
+++ b/MagicMirror/src/main/java/com/tomboshoven/minecraft/magicmirror/renderers/Renderers.java
@@ -1,8 +1,6 @@
 package com.tomboshoven.minecraft.magicmirror.renderers;
 
 import com.tomboshoven.minecraft.magicmirror.blocks.entities.BlockEntities;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
@@ -11,7 +9,6 @@ import net.minecraftforge.eventbus.api.IEventBus;
 /**
  * Manager of all renderers in the mod.
  */
-@OnlyIn(Dist.CLIENT)
 public final class Renderers {
     private Renderers() {
     }


### PR DESCRIPTION
Remove overhead of `OnlyIn` and `DistExecutor`.

Server and client code will be more cleanly isolated in a future iteration.