### PR TITLE
Bump versions of Neoforge and Parchment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     }
 
     dependencies {
-        implementation "net.neoforged:neoforge:21.5.62-beta"
+        implementation "net.neoforged:neoforge:21.5.75"
         implementation "org.spongepowered:mixin:0.8.7"
 
         implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 neogradle.subsystems.parchment.minecraftVersion=1.21.5
-neogradle.subsystems.parchment.mappingsVersion=2025.04.19
+neogradle.subsystems.parchment.mappingsVersion=2025.06.01


### PR DESCRIPTION
The beta version is compatible with stable, but we should use a stable version for continued development on this version.