### PR TITLE
Block-based texture lookups

### DIFF
--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
@@ -3,11 +3,8 @@ package com.tomboshoven.minecraft.magicdoorknob.blocks.entities;
 import com.tomboshoven.minecraft.magicdoorknob.items.Items;
 import com.tomboshoven.minecraft.magicdoorknob.items.MagicDoorknobItem;
 import com.tomboshoven.minecraft.magicdoorknob.modeldata.ModelTextureProperty;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.BlockModelShaper;
-import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
+import com.tomboshoven.minecraft.magicdoorknob.modeldata.TextureSourceReference;
 import net.minecraft.client.renderer.texture.TextureAtlas;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
@@ -46,6 +43,10 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
      * The highlight texture of the doorway (based on doorknob).
      */
     public static final ModelTextureProperty TEXTURE_HIGHLIGHT = ModelTextureProperty.get(ResourceLocation.fromNamespaceAndPath(PROPERTY_NAMESPACE, "texture_highlight"));
+
+    // Material to use when no proper material can be found, such as with air.
+    @SuppressWarnings("deprecation")
+    private static final Material EMPTY_MATERIAL = new Material(TextureAtlas.LOCATION_BLOCKS, ResourceLocation.fromNamespaceAndPath(MOD_ID, "block/empty"));
 
     // The block we're basing the appearance of this block on.
     private BlockState baseBlockState = Blocks.AIR.defaultBlockState();
@@ -108,34 +109,27 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
 
     @Override
     public @NotNull ModelData getModelData() {
-        Minecraft minecraft = Minecraft.getInstance();
-        BlockModelShaper blockModelShapes = minecraft.getBlockRenderer().getBlockModelShaper();
-
         // Get the base block texture
-        Level world = getLevel();
-        TextureAtlasSprite blockTexture = world == null ? null : blockModelShapes.getParticleIcon(baseBlockState, world, getBlockPos());
-        Material blockMaterial;
-        if (blockTexture == null || blockTexture == minecraft.getTextureAtlas(blockTexture.atlasLocation()).apply(MissingTextureAtlasSprite.getLocation())) {
-            // If we can't find the texture, use a transparent one instead, to deal with things like air.
-            //noinspection deprecation
-            blockMaterial = new Material(TextureAtlas.LOCATION_BLOCKS, ResourceLocation.fromNamespaceAndPath(MOD_ID, "block/empty"));
-        } else {
-            blockMaterial = new Material(blockTexture.atlasLocation(), blockTexture.contents().name());
-        }
+        Level level = getLevel();
+        BlockPos blockPos = getBlockPos();
 
-        // Get the highlight texture
-        Material doorknobMaterial;
-        if (doorknob != null) {
-            doorknobMaterial = doorknob.getMainMaterial();
-        } else {
+        // Fallback chain is block texture -> block particle texture -> empty
+        TextureSourceReference fallbackReference = new TextureSourceReference.MaterialTextureSource(EMPTY_MATERIAL);
+        TextureSourceReference blockTextureSourceReference = new TextureSourceReference.BlockLookup(level, blockPos, baseBlockState, fallbackReference);
+
+        TextureSourceReference doorknobTextureSourceReference;
+        if (doorknob == null) {
             // This can happen when we draw a frame before receiving the block entity data from the server.
-            // In that case, we just want to draw the outline to make it less conspicuous.
-            doorknobMaterial = blockMaterial;
+            // This makes it a bit less conspicuous.
+            doorknobTextureSourceReference = blockTextureSourceReference;
+        }
+        else {
+            doorknobTextureSourceReference = new TextureSourceReference.MaterialTextureSource(doorknob.getMainMaterial());
         }
 
         return ModelData.builder()
-                .with(TEXTURE_MAIN, blockMaterial)
-                .with(TEXTURE_HIGHLIGHT, doorknobMaterial)
+                .with(TEXTURE_MAIN, blockTextureSourceReference)
+                .with(TEXTURE_HIGHLIGHT, doorknobTextureSourceReference)
                 .build();
     }
 

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
@@ -120,7 +120,7 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
 
         // Fallback chain is block texture -> empty
         TextureSourceReference fallbackReference = new TextureSourceReference.MaterialTextureSource(EMPTY_MATERIAL);
-        TextureSourceReference particleTextureSourceReference = new TextureSourceReference.BlockParticle(level, blockPos, baseBlockState);
+        TextureSourceReference particleTextureSourceReference = new TextureSourceReference.BlockParticle(level, blockPos, baseBlockState, fallbackReference);
         TextureSourceReference blockTextureSourceReference = new TextureSourceReference.BlockLookup(level, blockPos, baseBlockState, fallbackReference);
 
         TextureSourceReference doorknobTextureSourceReference;

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
@@ -113,7 +113,7 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
         Level level = getLevel();
         BlockPos blockPos = getBlockPos();
 
-        // Fallback chain is block texture -> block particle texture -> empty
+        // Fallback chain is block texture -> empty
         TextureSourceReference fallbackReference = new TextureSourceReference.MaterialTextureSource(EMPTY_MATERIAL);
         TextureSourceReference blockTextureSourceReference = new TextureSourceReference.BlockLookup(level, blockPos, baseBlockState, fallbackReference);
 

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/blocks/entities/MagicDoorwayPartBaseBlockEntity.java
@@ -44,6 +44,11 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
      */
     public static final ModelTextureProperty TEXTURE_HIGHLIGHT = ModelTextureProperty.get(ResourceLocation.fromNamespaceAndPath(PROPERTY_NAMESPACE, "texture_highlight"));
 
+    /**
+     * The particle texture of the doorway (based on base block particle texture).
+     */
+    public static final ModelTextureProperty TEXTURE_PARTICLE = ModelTextureProperty.get(ResourceLocation.fromNamespaceAndPath(PROPERTY_NAMESPACE, "texture_particle"));
+
     // Material to use when no proper material can be found, such as with air.
     @SuppressWarnings("deprecation")
     private static final Material EMPTY_MATERIAL = new Material(TextureAtlas.LOCATION_BLOCKS, ResourceLocation.fromNamespaceAndPath(MOD_ID, "block/empty"));
@@ -115,6 +120,7 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
 
         // Fallback chain is block texture -> empty
         TextureSourceReference fallbackReference = new TextureSourceReference.MaterialTextureSource(EMPTY_MATERIAL);
+        TextureSourceReference particleTextureSourceReference = new TextureSourceReference.BlockParticle(level, blockPos, baseBlockState);
         TextureSourceReference blockTextureSourceReference = new TextureSourceReference.BlockLookup(level, blockPos, baseBlockState, fallbackReference);
 
         TextureSourceReference doorknobTextureSourceReference;
@@ -130,6 +136,7 @@ public abstract class MagicDoorwayPartBaseBlockEntity extends BlockEntity {
         return ModelData.builder()
                 .with(TEXTURE_MAIN, blockTextureSourceReference)
                 .with(TEXTURE_HIGHLIGHT, doorknobTextureSourceReference)
+                .with(TEXTURE_PARTICLE, particleTextureSourceReference)
                 .build();
     }
 

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/ModelLoaders.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/ModelLoaders.java
@@ -11,7 +11,6 @@ import static com.tomboshoven.minecraft.magicdoorknob.MagicDoorknobMod.MOD_ID;
  * Collection of custom model loaders.
  */
 public final class ModelLoaders {
-    public static final ResourceLocation TEXTURED_MODEL_LOADER_KEY = ResourceLocation.fromNamespaceAndPath(MOD_ID, "textured");
     public static final ResourceLocation BLOCK_STATE_MODEL_DEFINITION_KEY = ResourceLocation.fromNamespaceAndPath(MOD_ID, "textured");
 
     private ModelLoaders() {

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/ModelDataTextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/ModelDataTextureMapper.java
@@ -1,9 +1,9 @@
 package com.tomboshoven.minecraft.magicdoorknob.client.modelloaders.textured;
 
 import com.tomboshoven.minecraft.magicdoorknob.modeldata.ModelTextureProperty;
+import com.tomboshoven.minecraft.magicdoorknob.modeldata.TextureSourceReference;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
-import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.model.data.ModelData;
@@ -23,7 +23,7 @@ class ModelDataTextureMapper implements TextureMapper {
             return new BlockStateTextureMapper.Empty();
         }
 
-        Map<ModelTextureProperty, Material> lookup = distill(modelData);
+        Map<ModelTextureProperty, TextureSourceReference> lookup = distill(modelData);
         return new BlockStateTextureMapper() {
             @Override
             public Object getMappingKey() {
@@ -32,9 +32,9 @@ class ModelDataTextureMapper implements TextureMapper {
             }
 
             @Override
-            public @Nullable Material mapSprite(PropertySprite spriteToMap) {
+            public @Nullable TextureSourceReference mapSprite(PropertySprite spriteToMap) {
                 ResourceLocation name = spriteToMap.contents().name();
-                ModelProperty<Material> modelProperty = ModelTextureProperty.get(name);
+                ModelProperty<TextureSourceReference> modelProperty = ModelTextureProperty.get(name);
                 return lookup.get(modelProperty);
             }
         };
@@ -47,11 +47,11 @@ class ModelDataTextureMapper implements TextureMapper {
      * @param modelData The model data to distill down.
      * @return A map containing all the potentially relevant properties and their values.
      */
-    private static Map<ModelTextureProperty, Material> distill(ModelData modelData) {
-        Map<ModelTextureProperty, Material> result = new Reference2ObjectArrayMap<>();
+    private static Map<ModelTextureProperty, TextureSourceReference> distill(ModelData modelData) {
+        Map<ModelTextureProperty, TextureSourceReference> result = new Reference2ObjectArrayMap<>();
         for (ModelProperty<?> property : modelData.getProperties()) {
             if (property instanceof ModelTextureProperty modelTextureProperty) {
-                Material value = modelData.get(modelTextureProperty);
+                TextureSourceReference value = modelData.get(modelTextureProperty);
                 if (value != null) {
                     result.put(modelTextureProperty, value);
                 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TextureMapper.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TextureMapper.java
@@ -1,6 +1,6 @@
 package com.tomboshoven.minecraft.magicdoorknob.client.modelloaders.textured;
 
-import net.minecraft.client.resources.model.Material;
+import com.tomboshoven.minecraft.magicdoorknob.modeldata.TextureSourceReference;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.model.data.ModelData;
 
@@ -33,10 +33,10 @@ public interface TextureMapper {
 
         /**
          * @param spriteToMap The property to get the texture location for.
-         * @return The appropriate material.
+         * @return The appropriate texture reference.
          */
         @Nullable
-        Material mapSprite(PropertySprite spriteToMap);
+        TextureSourceReference mapSprite(PropertySprite spriteToMap);
 
         /**
          * A very basic implementation of a texture mapper that never maps any textures.
@@ -51,7 +51,7 @@ public interface TextureMapper {
 
             @Nullable
             @Override
-            public Material mapSprite(PropertySprite spriteToMap) {
+            public TextureSourceReference mapSprite(PropertySprite spriteToMap) {
                 return null;
             }
         }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockModelPart.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockModelPart.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.SpriteGetter;
 import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
 
 import javax.annotation.Nullable;
@@ -27,6 +28,8 @@ class TexturedBlockModelPart implements BlockModelPart {
     private final SpriteGetter sprites;
     // The mapper that replaces property textures by their values
     private final TextureMapper.BlockStateTextureMapper textureMapper;
+    // The random source for texture lookups
+    private final RandomSource randomSource;
 
     // The vertex format of the model. At the moment, only "block" is supported.
     private static final VertexFormat VERTEX_FORMAT = DefaultVertexFormat.BLOCK;
@@ -35,11 +38,13 @@ class TexturedBlockModelPart implements BlockModelPart {
      * @param original      The original block model part
      * @param textureMapper The mapper that replaces property textures by their values
      * @param sprites       The sprite getter
+     * @param randomSource  The random source for texture lookups
      */
-    TexturedBlockModelPart(BlockModelPart original, TextureMapper.BlockStateTextureMapper textureMapper, SpriteGetter sprites) {
+    TexturedBlockModelPart(BlockModelPart original, TextureMapper.BlockStateTextureMapper textureMapper, SpriteGetter sprites, RandomSource randomSource) {
         this.original = original;
         this.sprites = sprites;
         this.textureMapper = textureMapper;
+        this.randomSource = randomSource;
     }
 
     @Override
@@ -51,7 +56,7 @@ class TexturedBlockModelPart implements BlockModelPart {
             if (sprite instanceof PropertySprite property) {
                 TextureSourceReference textureSourceReference = textureMapper.mapSprite(property);
                 if (textureSourceReference != null) {
-                    TextureSourceReference.LookupResult lookupResult = textureSourceReference.lookup(sprites, quad.direction());
+                    TextureSourceReference.LookupResult lookupResult = textureSourceReference.lookup(sprites, quad.direction(), randomSource);
                     return retexture(quad, lookupResult.sprite(), lookupResult.tintIndex());
                 }
                 return null;

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockModelPart.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockModelPart.java
@@ -138,7 +138,7 @@ class TexturedBlockModelPart implements BlockModelPart {
         if (icon instanceof PropertySprite property) {
             TextureSourceReference textureSourceReference = textureMapper.mapSprite(property);
             if (textureSourceReference != null) {
-                return textureSourceReference.lookup(sprites).sprite();
+                return textureSourceReference.lookup(sprites, randomSource).sprite();
             }
         }
         return icon;

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockStateModel.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockStateModel.java
@@ -72,7 +72,7 @@ public class TexturedBlockStateModel extends DelegateBlockStateModel {
         List<BlockModelPart> delegatePartList = partCache.computeIfAbsent(mapper.getMappingKey(), key -> {
             List<BlockModelPart> partList = new ArrayList<>();
             delegate.collectParts(level, pos, state, random, partList);
-            partList.replaceAll(part -> wrapPart(part, mapper));
+            partList.replaceAll(part -> wrapPart(part, mapper, random));
             return partList;
         });
         parts.addAll(delegatePartList);
@@ -96,9 +96,10 @@ public class TexturedBlockStateModel extends DelegateBlockStateModel {
      *
      * @param basePart The part to wrap.
      * @param mapper   The texture mapper to use.
+     * @param random   The random source for the part collection.
      * @return The wrapped block model part.
      */
-    private BlockModelPart wrapPart(BlockModelPart basePart, TextureMapper.BlockStateTextureMapper mapper) {
-        return new TexturedBlockModelPart(basePart, mapper, sprites);
+    private BlockModelPart wrapPart(BlockModelPart basePart, TextureMapper.BlockStateTextureMapper mapper, RandomSource random) {
+        return new TexturedBlockModelPart(basePart, mapper, sprites, random);
     }
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockStateModel.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/client/modelloaders/textured/TexturedBlockStateModel.java
@@ -1,9 +1,9 @@
 package com.tomboshoven.minecraft.magicdoorknob.client.modelloaders.textured;
 
+import com.tomboshoven.minecraft.magicdoorknob.modeldata.TextureSourceReference;
 import net.minecraft.client.renderer.block.model.BlockModelPart;
 import net.minecraft.client.renderer.block.model.BlockStateModel;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.SpriteGetter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
@@ -83,11 +83,10 @@ public class TexturedBlockStateModel extends DelegateBlockStateModel {
         TextureAtlasSprite baseIcon = delegate.particleIcon(level, pos, state);
         if (baseIcon instanceof PropertySprite baseIconProperty) {
             ModelData modelData = level.getModelData(pos);
-            Material material = textureMapper.forBlockState(state, modelData).mapSprite(baseIconProperty);
-            if (material == null) {
-                return baseIcon;
+            TextureSourceReference textureSourceReference = textureMapper.forBlockState(state, modelData).mapSprite(baseIconProperty);
+            if (textureSourceReference != null) {
+                return textureSourceReference.lookup(sprites).sprite();
             }
-            return sprites.get(material, () -> "TexturedBlockStateModel");
         }
         return baseIcon;
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
@@ -398,7 +398,7 @@ class Models extends ModelProvider {
         if (partType == MagicDoorwayPartBaseBlock.EnumPartType.TOP) {
             startY = 1;
             // Add the ceiling
-            builder.element(panelCuboid(Direction.UP, 0, 0, 16, 16, mainTextureAction));
+            builder.element(top(mainTextureAction));
         } else {
             startY = 0;
         }
@@ -483,7 +483,7 @@ class Models extends ModelProvider {
         if (partType == MagicDoorwayPartBaseBlock.EnumPartType.TOP) {
             startY = 1;
             // Add the ceiling
-            builder.element(panelCuboid(Direction.UP, 0, 0, 16, 16, mainTextureAction));
+            builder.element(top(mainTextureAction));
         } else {
             startY = 0;
         }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
@@ -228,6 +228,23 @@ class Models extends ModelProvider {
     }
 
     /**
+     * Create a 1-thick ceiling on the top of the block.
+     * The top and bottom are textured like a regular block, while the sides are textured to match the behavior of the
+     * {@link #wallCuboid} method.
+     *
+     * @param faceAction The face action to apply to all faces. Used for setting textures.
+     */
+    private static Consumer<ElementBuilder> top(BiConsumer<Direction, FaceBuilder> faceAction) {
+        return elementBuilder -> elementBuilder.from(0, 15, 0).to(16, 16, 16).allFaces(faceAction)
+                // Fix up texture alignment to match panels
+                .allFaces((d, faceBuilder) -> {
+                    if (d.getAxis().isHorizontal()) {
+                        faceBuilder.uvs(0, 0, 16, 1);
+                    }
+                });
+    }
+
+    /**
      * Create a cuboid that is textured on the north and south faces (mirrored) and stretched along the other faces.
      * Mainly useful for 1-thick cuboids or intersected ones.
      */
@@ -425,7 +442,7 @@ class Models extends ModelProvider {
         if (partType == MagicDoorwayPartBaseBlock.EnumPartType.TOP) {
             startY = 1;
             // Add the ceiling
-            builder.element(panelCuboid(Direction.UP, 0, 0, 16, 16, mainTextureAction));
+            builder.element(top(mainTextureAction));
         } else {
             startY = 0;
         }
@@ -509,9 +526,10 @@ class Models extends ModelProvider {
         ExtendedModelTemplate doorknobTemplate = doorknobTemplate(doorknobBaseModelLocation);
         for (DeferredItem<MagicDoorknobItem> item : Items.DOORKNOBS.values()) {
             MagicDoorknobItem doorknobItem = item.get();
+            ResourceLocation texture = doorknobItem.getMainMaterial().texture();
             ResourceLocation modelLocation = doorknobTemplate.create(
                     doorknobItem,
-                    new TextureMapping().put(MAIN_TEXTURE, doorknobItem.getMainMaterial().texture()),
+                    new TextureMapping().put(MAIN_TEXTURE, texture).put(TextureSlot.PARTICLE, texture),
                     itemModels.modelOutput
             );
             itemModels.itemModelOutput.accept(doorknobItem, new BlockModelWrapper.Unbaked(

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
@@ -540,7 +540,7 @@ class Models extends ModelProvider {
 
         // Door blocks
         TextureMapping panelTextureMapping = new TextureMapping()
-                .put(TextureSlot.PARTICLE, MagicDoorwayPartBaseBlockEntity.TEXTURE_MAIN.getName())
+                .put(TextureSlot.PARTICLE, MagicDoorwayPartBaseBlockEntity.TEXTURE_PARTICLE.getName())
                 .put(MAIN_TEXTURE, MagicDoorwayPartBaseBlockEntity.TEXTURE_MAIN.getName())
                 .put(HIGHLIGHT_TEXTURE, MagicDoorwayPartBaseBlockEntity.TEXTURE_HIGHLIGHT.getName());
         doorTemplate(MagicDoorwayPartBaseBlock.EnumPartType.TOP).create(doorTopModelLocation, panelTextureMapping, blockModels.modelOutput);

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/data/Models.java
@@ -235,11 +235,11 @@ class Models extends ModelProvider {
      * @param faceAction The face action to apply to all faces. Used for setting textures.
      */
     private static Consumer<ElementBuilder> top(BiConsumer<Direction, FaceBuilder> faceAction) {
-        return elementBuilder -> elementBuilder.from(0, 15, 0).to(16, 16, 16).allFaces(faceAction)
-                // Fix up texture alignment to match panels
+        return elementBuilder -> elementBuilder.from(0, 15, 0).to(16, 16, 16)
+                .allFaces(faceAction)
                 .allFaces((d, faceBuilder) -> {
-                    if (d.getAxis().isHorizontal()) {
-                        faceBuilder.uvs(0, 0, 16, 1);
+                    if (d != Direction.DOWN) {
+                        faceBuilder.cullface(d);
                     }
                 });
     }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/ModelTextureProperty.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/ModelTextureProperty.java
@@ -1,7 +1,6 @@
 package com.tomboshoven.minecraft.magicdoorknob.modeldata;
 
 import com.google.common.collect.Maps;
-import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.model.data.ModelProperty;
 import org.jetbrains.annotations.NonNls;
@@ -12,7 +11,7 @@ import java.util.Objects;
 /**
  * Model property pointing to a texture.
  */
-public final class ModelTextureProperty extends ModelProperty<Material> {
+public final class ModelTextureProperty extends ModelProperty<TextureSourceReference> {
     // The namespace of the properties; used in model definitions
     public static final @NonNls String PROPERTY_NAMESPACE = "property";
 

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
@@ -38,17 +38,18 @@ public interface TextureSourceReference {
      * @return The result of the lookup.
      */
     default LookupResult lookup(SpriteGetter sprites) {
-        return lookup(sprites, Direction.NORTH);
+        return lookup(sprites, Direction.NORTH, RandomSource.create());
     }
 
     /**
      * Perform the actual lookup.
      *
-     * @param sprites   The sprite getter to use for looking up texture references.
-     * @param direction The direction of the side to get the texture for.
+     * @param sprites      The sprite getter to use for looking up texture references.
+     * @param direction    The direction of the side to get the texture for.
+     * @param randomSource A random source to use in the texture lookup.
      * @return The result of the lookup.
      */
-    LookupResult lookup(SpriteGetter sprites, Direction direction);
+    LookupResult lookup(SpriteGetter sprites, Direction direction, RandomSource randomSource);
 
     /**
      * A direct reference to a material.
@@ -57,7 +58,7 @@ public interface TextureSourceReference {
      */
     record MaterialTextureSource(Material material) implements TextureSourceReference {
         @Override
-        public LookupResult lookup(SpriteGetter sprites, Direction direction) {
+        public LookupResult lookup(SpriteGetter sprites, Direction direction, RandomSource randomSource) {
             return new LookupResult(sprites.get(material, () -> "TextureReference"), null);
         }
     }
@@ -76,11 +77,10 @@ public interface TextureSourceReference {
     record BlockLookup(@Nullable Level level, BlockPos pos, BlockState blockState,
                        TextureSourceReference fallback) implements TextureSourceReference {
         @Override
-        public LookupResult lookup(SpriteGetter sprites, Direction direction) {
+        public LookupResult lookup(SpriteGetter sprites, Direction direction, RandomSource randomSource) {
             Minecraft minecraft = Minecraft.getInstance();
             BlockModelShaper blockModelShaper = minecraft.getBlockRenderer().getBlockModelShaper();
             BlockStateModel blockModel = blockModelShaper.getBlockModel(blockState);
-            RandomSource randomSource = RandomSource.create();
             List<BlockModelPart> parts = new ObjectArrayList<>();
             if (level == null) {
                 //noinspection deprecation
@@ -103,7 +103,7 @@ public interface TextureSourceReference {
                     return new LookupResult(quad.sprite(), quad.tintIndex());
                 }
             }
-            return fallback.lookup(sprites, direction);
+            return fallback.lookup(sprites, direction, randomSource);
         }
     }
 }

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
@@ -38,7 +38,18 @@ public interface TextureSourceReference {
      * @return The result of the lookup.
      */
     default LookupResult lookup(SpriteGetter sprites) {
-        return lookup(sprites, Direction.NORTH, RandomSource.create());
+        return lookup(sprites, RandomSource.create());
+    }
+
+    /**
+     * Perform the actual lookup.
+     *
+     * @param sprites The sprite getter to use for looking up texture references.
+     * @param randomSource A random source to use in the texture lookup.
+     * @return The result of the lookup.
+     */
+    default LookupResult lookup(SpriteGetter sprites, RandomSource randomSource) {
+        return lookup(sprites, Direction.NORTH, randomSource);
     }
 
     /**

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
@@ -1,0 +1,109 @@
+package com.tomboshoven.minecraft.magicdoorknob.modeldata;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.BlockModelShaper;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.BlockModelPart;
+import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.SpriteGetter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A reference to something that is associated with a texture, such as a material or a block in the world.
+ */
+public interface TextureSourceReference {
+    /**
+     * The result of a lookup, containing a sprite and optionally a tint index to use.
+     *
+     * @param sprite    The sprite resulting from the lookup.
+     * @param tintIndex The tint index to use, if any was found in the source.
+     */
+    record LookupResult(TextureAtlasSprite sprite, @Nullable Integer tintIndex) {
+    }
+
+    /**
+     * Perform the actual lookup.
+     *
+     * @param sprites The sprite getter to use for looking up texture references.
+     * @return The result of the lookup.
+     */
+    default LookupResult lookup(SpriteGetter sprites) {
+        return lookup(sprites, Direction.NORTH);
+    }
+
+    /**
+     * Perform the actual lookup.
+     *
+     * @param sprites   The sprite getter to use for looking up texture references.
+     * @param direction The direction of the side to get the texture for.
+     * @return The result of the lookup.
+     */
+    LookupResult lookup(SpriteGetter sprites, Direction direction);
+
+    /**
+     * A direct reference to a material.
+     *
+     * @param material The material referring to the texture to use.
+     */
+    record MaterialTextureSource(Material material) implements TextureSourceReference {
+        @Override
+        public LookupResult lookup(SpriteGetter sprites, Direction direction) {
+            return new LookupResult(sprites.get(material, () -> "TextureReference"), null);
+        }
+    }
+
+    /**
+     * A reference to a block in the world.
+     * The block doesn't actually need to exist in the level at the provided position, but if the model relies on model
+     * data, the result may not be great.
+     * If the block is textured, its textures are looked up on a best-effort basis.
+     *
+     * @param level      The level (hypothetically) containing the block. May be left null for an agnostic lookup.
+     * @param pos        The position of the block in the level.
+     * @param blockState The block state of the block.
+     * @param fallback   A fallback to use in case no appropriate textures are found on the block model.
+     */
+    record BlockLookup(@Nullable Level level, BlockPos pos, BlockState blockState,
+                       TextureSourceReference fallback) implements TextureSourceReference {
+        @Override
+        public LookupResult lookup(SpriteGetter sprites, Direction direction) {
+            Minecraft minecraft = Minecraft.getInstance();
+            BlockModelShaper blockModelShaper = minecraft.getBlockRenderer().getBlockModelShaper();
+            BlockStateModel blockModel = blockModelShaper.getBlockModel(blockState);
+            RandomSource randomSource = RandomSource.create();
+            List<BlockModelPart> parts = new ObjectArrayList<>();
+            if (level == null) {
+                //noinspection deprecation
+                blockModel.collectParts(randomSource, parts);
+            } else {
+                blockModel.collectParts(level, pos, blockState, randomSource, parts);
+            }
+            for (BlockModelPart part : parts) {
+                // First try the actual direction we're going for.
+                for (BakedQuad quad : part.getQuads(direction)) {
+                    return new LookupResult(quad.sprite(), quad.tintIndex());
+                }
+                // Fall back on any other ones, if they're there.
+                // This will make cross blocks textures a bit better.
+                for (BakedQuad quad : part.getQuads(null)) {
+                    // Separate out the sides from top and bottom, because those are often not compatible
+                    if (quad.direction().getAxis().isVertical() != direction.getAxis().isVertical()) {
+                        continue;
+                    }
+                    return new LookupResult(quad.sprite(), quad.tintIndex());
+                }
+            }
+            return fallback.lookup(sprites, direction);
+        }
+    }
+}

--- a/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
+++ b/MagicDoorknob/src/main/java/com/tomboshoven/minecraft/magicdoorknob/modeldata/TextureSourceReference.java
@@ -99,6 +99,7 @@ public interface TextureSourceReference {
             } else {
                 blockModel.collectParts(level, pos, blockState, randomSource, parts);
             }
+            LookupResult result = null;
             for (BlockModelPart part : parts) {
                 // First try the actual direction we're going for.
                 for (BakedQuad quad : part.getQuads(direction)) {
@@ -108,13 +109,21 @@ public interface TextureSourceReference {
                 // This will make cross blocks textures a bit better.
                 for (BakedQuad quad : part.getQuads(null)) {
                     // Separate out the sides from top and bottom, because those are often not compatible
-                    if (quad.direction().getAxis().isVertical() != direction.getAxis().isVertical()) {
+                    Direction quadDirection = quad.direction();
+                    if (quadDirection.getAxis().isVertical() != direction.getAxis().isVertical()) {
                         continue;
                     }
-                    return new LookupResult(quad.sprite(), quad.tintIndex());
+                    result = new LookupResult(quad.sprite(), quad.tintIndex());
+                    // Always prefer a direction match
+                    if (quadDirection == direction) {
+                        return result;
+                    }
                 }
             }
-            return fallback.lookup(sprites, direction, randomSource);
+            if (result == null) {
+                return fallback.lookup(sprites, direction, randomSource);
+            }
+            return result;
         }
     }
 }


### PR DESCRIPTION
Provide more accurate textures by looking them up in the block models.

This should improve #434 .
Fully resolving that will be hard, because of overlays and otherwise irregular blocks.